### PR TITLE
fix(core): improve thread safety and add comprehensive tests

### DIFF
--- a/tests/ShortcutsTests/ParserTests.cs
+++ b/tests/ShortcutsTests/ParserTests.cs
@@ -99,4 +99,225 @@ public class ParserTests
 
         Assert.Equal(shortcut1.StableId, shortcut2.StableId);
     }
+
+    [Fact]
+    public void StableId_EmptyExeAndName_ReturnsConsistentHash()
+    {
+        var shortcut1 = new SteamShortcut { AppName = "", Exe = "" };
+        var shortcut2 = new SteamShortcut { AppName = "", Exe = "" };
+
+        Assert.Equal(shortcut1.StableId, shortcut2.StableId);
+        Assert.False(string.IsNullOrEmpty(shortcut1.StableId));
+    }
+
+    [Fact]
+    public void StableId_NullValues_HandledGracefully()
+    {
+        var shortcut = new SteamShortcut { AppName = null!, Exe = null! };
+        
+        // Should not throw and should return a valid hash
+        var stableId = shortcut.StableId;
+        Assert.False(string.IsNullOrEmpty(stableId));
+    }
+
+    [Fact]
+    public void StableId_CaseSensitiveForName()
+    {
+        var shortcut1 = new SteamShortcut { AppName = "Test Game", Exe = "game.exe" };
+        var shortcut2 = new SteamShortcut { AppName = "test game", Exe = "game.exe" };
+
+        // Names are case-sensitive
+        Assert.NotEqual(shortcut1.StableId, shortcut2.StableId);
+    }
+
+    [Fact]
+    public void StableId_ForwardAndBackslashPaths_AreDifferent()
+    {
+        // Paths with different separators should produce different IDs
+        // (normalization only removes quotes, doesn't change separators)
+        var shortcut1 = new SteamShortcut { AppName = "Game", Exe = "C:\\Games\\game.exe" };
+        var shortcut2 = new SteamShortcut { AppName = "Game", Exe = "C:/Games/game.exe" };
+
+        // These should be different since we don't normalize path separators
+        Assert.NotEqual(shortcut1.StableId, shortcut2.StableId);
+    }
+
+    [Fact]
+    public void Read_NonexistentFile_ThrowsFileNotFoundException()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), "nonexistent_" + Guid.NewGuid().ToString("N") + ".vdf");
+        
+        Assert.Throws<FileNotFoundException>(() => ShortcutsFile.Read(nonExistentPath).ToList());
+    }
+
+    [Fact]
+    public void Write_EmptyList_CreatesValidFile()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "shortcuts_empty_" + Guid.NewGuid().ToString("N") + ".vdf");
+
+        try
+        {
+            ShortcutsFile.Write(tmp, Array.Empty<SteamShortcut>());
+            
+            Assert.True(File.Exists(tmp));
+            
+            // Should be readable and return empty list
+            var items = ShortcutsFile.Read(tmp).ToList();
+            Assert.Empty(items);
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_MultipleShortcuts_PreservesOrder()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "shortcuts_order_" + Guid.NewGuid().ToString("N") + ".vdf");
+
+        try
+        {
+            var shortcuts = new[]
+            {
+                new SteamShortcut { AppName = "Game A", Exe = "a.exe" },
+                new SteamShortcut { AppName = "Game B", Exe = "b.exe" },
+                new SteamShortcut { AppName = "Game C", Exe = "c.exe" }
+            };
+
+            ShortcutsFile.Write(tmp, shortcuts);
+            var items = ShortcutsFile.Read(tmp).ToList();
+
+            Assert.Equal(3, items.Count);
+            Assert.Equal("Game A", items[0].AppName);
+            Assert.Equal("Game B", items[1].AppName);
+            Assert.Equal("Game C", items[2].AppName);
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesAllFields()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "shortcuts_fields_" + Guid.NewGuid().ToString("N") + ".vdf");
+
+        try
+        {
+            var original = new SteamShortcut
+            {
+                AppName = "Full Game",
+                Exe = "C:\\Games\\Full\\full.exe",
+                StartDir = "C:\\Games\\Full",
+                Icon = "C:\\Games\\Full\\icon.ico",
+                ShortcutPath = "",
+                LaunchOptions = "-fullscreen -vsync",
+                AppId = 0x80001234,
+                IsHidden = 1,
+                AllowDesktopConfig = 0,
+                AllowOverlay = 1,
+                OpenVR = 1,
+                Tags = new System.Collections.Generic.List<string> { "Action", "RPG", "Favorite" }
+            };
+
+            ShortcutsFile.Write(tmp, new[] { original });
+            var items = ShortcutsFile.Read(tmp).ToList();
+
+            Assert.Single(items);
+            var loaded = items[0];
+
+            Assert.Equal(original.AppName, loaded.AppName);
+            Assert.Contains("full.exe", loaded.Exe); // May be quoted
+            Assert.Equal(original.StartDir, loaded.StartDir);
+            Assert.Equal(original.Icon, loaded.Icon);
+            Assert.Equal(original.LaunchOptions, loaded.LaunchOptions);
+            Assert.Equal(original.AppId, loaded.AppId);
+            Assert.Equal(original.IsHidden, loaded.IsHidden);
+            Assert.Equal(original.AllowDesktopConfig, loaded.AllowDesktopConfig);
+            Assert.Equal(original.AllowOverlay, loaded.AllowOverlay);
+            Assert.Equal(original.OpenVR, loaded.OpenVR);
+            Assert.NotNull(loaded.Tags);
+            Assert.Equal(3, loaded.Tags!.Count);
+            Assert.Contains("Action", loaded.Tags);
+            Assert.Contains("RPG", loaded.Tags);
+            Assert.Contains("Favorite", loaded.Tags);
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_HandlesSpecialCharactersInName()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "shortcuts_special_" + Guid.NewGuid().ToString("N") + ".vdf");
+
+        try
+        {
+            var shortcuts = new[]
+            {
+                new SteamShortcut { AppName = "Game: The Sequel (2024)", Exe = "game.exe" },
+                new SteamShortcut { AppName = "日本語ゲーム", Exe = "japanese.exe" },
+                new SteamShortcut { AppName = "Émojis 🎮 & Symbols™", Exe = "emoji.exe" }
+            };
+
+            ShortcutsFile.Write(tmp, shortcuts);
+            var items = ShortcutsFile.Read(tmp).ToList();
+
+            Assert.Equal(3, items.Count);
+            Assert.Equal("Game: The Sequel (2024)", items[0].AppName);
+            Assert.Equal("日本語ゲーム", items[1].AppName);
+            Assert.Equal("Émojis 🎮 & Symbols™", items[2].AppName);
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip_HandlesPathsWithSpaces()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "shortcuts_spaces_" + Guid.NewGuid().ToString("N") + ".vdf");
+
+        try
+        {
+            var shortcut = new SteamShortcut
+            {
+                AppName = "Space Game",
+                Exe = "C:\\Program Files (x86)\\My Games\\Space Game\\game.exe",
+                StartDir = "C:\\Program Files (x86)\\My Games\\Space Game"
+            };
+
+            ShortcutsFile.Write(tmp, new[] { shortcut });
+            var items = ShortcutsFile.Read(tmp).ToList();
+
+            Assert.Single(items);
+            // Exe should contain the path (may be quoted)
+            Assert.Contains("Program Files (x86)", items[0].Exe);
+            Assert.Contains("Space Game", items[0].Exe);
+        }
+        finally
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
 }

--- a/tests/ShortcutsTests/UtilsTests.cs
+++ b/tests/ShortcutsTests/UtilsTests.cs
@@ -115,4 +115,124 @@ public class UtilsTests
         // Standard CRC32 of "123456789" is 0xCBF43926
         Assert.Equal(0xCBF43926u, crc);
     }
+
+    [Fact]
+    public void HashString_EmptyString_ReturnsValidHash()
+    {
+        var hash = Utils.HashString("");
+        
+        Assert.False(string.IsNullOrEmpty(hash));
+        Assert.Equal(16, hash.Length); // 64-bit hex = 16 chars
+    }
+
+    [Fact]
+    public void HashString_WhitespaceOnly_ReturnsValidHash()
+    {
+        var hash1 = Utils.HashString(" ");
+        var hash2 = Utils.HashString("  ");
+        var hash3 = Utils.HashString("\t");
+        
+        Assert.False(string.IsNullOrEmpty(hash1));
+        Assert.False(string.IsNullOrEmpty(hash2));
+        Assert.False(string.IsNullOrEmpty(hash3));
+        
+        // Different whitespace should produce different hashes
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashString_UnicodeCharacters_HandlesCorrectly()
+    {
+        var hash1 = Utils.HashString("日本語");
+        var hash2 = Utils.HashString("Émojis 🎮");
+        
+        Assert.False(string.IsNullOrEmpty(hash1));
+        Assert.False(string.IsNullOrEmpty(hash2));
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashString_LongString_ReturnsValidHash()
+    {
+        var longString = new string('a', 10000);
+        var hash = Utils.HashString(longString);
+        
+        Assert.False(string.IsNullOrEmpty(hash));
+        Assert.Equal(16, hash.Length);
+    }
+
+    [Fact]
+    public void Crc32_EmptyArray_ReturnsZero()
+    {
+        var crc = Utils.Crc32(Array.Empty<byte>());
+        
+        // CRC32 of empty input is 0x00000000
+        Assert.Equal(0u, crc);
+    }
+
+    [Fact]
+    public void Crc32_SingleByte_ReturnsExpectedValue()
+    {
+        // Known test case: CRC32 of single byte 0x00 is 0xD202EF8D
+        var crc = Utils.Crc32(new byte[] { 0x00 });
+        Assert.Equal(0xD202EF8Du, crc);
+    }
+
+    [Fact]
+    public void GenerateShortcutAppId_SameExeDifferentName_DifferentIds()
+    {
+        var appId1 = Utils.GenerateShortcutAppId("game.exe", "Game 1");
+        var appId2 = Utils.GenerateShortcutAppId("game.exe", "Game 2");
+        
+        Assert.NotEqual(appId1, appId2);
+    }
+
+    [Fact]
+    public void GenerateShortcutAppId_SameNameDifferentExe_DifferentIds()
+    {
+        var appId1 = Utils.GenerateShortcutAppId("game1.exe", "Game");
+        var appId2 = Utils.GenerateShortcutAppId("game2.exe", "Game");
+        
+        Assert.NotEqual(appId1, appId2);
+    }
+
+    [Fact]
+    public void ToShortcutGameId_ZeroAppId_ReturnsBaseValue()
+    {
+        ulong gameId = Utils.ToShortcutGameId(0);
+        
+        // Should still return the base 0x02000000
+        Assert.Equal(0x02000000UL, gameId);
+    }
+
+    [Fact]
+    public void ToShortcutGameId_MaxAppId_HandlesCorrectly()
+    {
+        ulong gameId = Utils.ToShortcutGameId(uint.MaxValue);
+        
+        ulong expected = ((ulong)uint.MaxValue << 32) | 0x02000000UL;
+        Assert.Equal(expected, gameId);
+    }
+
+    [Fact]
+    public void NormalizePath_OnlyQuotes_ReturnsEmpty()
+    {
+        Assert.Equal("", Utils.NormalizePath("\"\""));
+    }
+
+    [Fact]
+    public void NormalizePath_SingleQuote_ReturnsAsIs()
+    {
+        // Single quote at start or end is not a pair, so preserved after trim
+        Assert.Equal("\"", Utils.NormalizePath("\""));
+        Assert.Equal("test\"", Utils.NormalizePath("test\""));
+        Assert.Equal("\"test", Utils.NormalizePath("\"test"));
+    }
+
+    [Fact]
+    public void NormalizePath_NestedQuotes_RemovesOuterOnly()
+    {
+        // "\"path\"" -> "path" (outer quotes removed)
+        Assert.Equal("\"path\"", Utils.NormalizePath("\"\"path\"\""));
+    }
 }


### PR DESCRIPTION
## Summary

- Fix critical thread safety issues in timer disposal using `Interlocked.Exchange` pattern
- Add null check for `ExportMap` iteration to prevent potential `NullReferenceException`
- Add 23 new unit tests for edge cases and robustness (80 → 103 total)

## Changes

### Critical Fixes
1. **Thread-safe timer disposal** - The debounce timer in `Games_ItemUpdated` could race with `Dispose()`, potentially causing issues. Now uses atomic exchange pattern.
2. **Null reference prevention** - Added defensive null check before iterating `Settings.ExportMap`

### New Tests
| Area | Tests Added |
|------|-------------|
| `ParserTests.cs` | StableId edge cases, file read/write edge cases, round-trip validation, special characters |
| `UtilsTests.cs` | HashString null/empty/unicode, Crc32 edge cases, NormalizePath edge cases |