### PR TITLE
feat(settings): add Steam user selection for multi-account support

### DIFF
--- a/src/SteamShortcutsImporter/Constants.cs
+++ b/src/SteamShortcutsImporter/Constants.cs
@@ -115,4 +115,9 @@ internal static class Constants
     public const string SteamRestartConfirmMessage = "Steam will be restarted to complete this operation.\n\n" +
         "This ensures shortcuts are written safely without corruption.\n\n" +
         "Do you want to continue?";
+
+    // Steam user selection UI
+    public const string SteamUserLabel = "Default Steam user:";
+    public const string AutoDetectUserLabel = "(Auto-detect)";
+    public const string SteamUserFallbackFormat = "Steam User {0}";
 }

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -36,7 +36,7 @@ internal class ImportExportService
     /// </summary>
     public void ShowImportDialog()
     {
-        var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+        var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_library.Settings.SelectedSteamUserId);
         if (string.IsNullOrWhiteSpace(vdfPath) || !File.Exists(vdfPath))
         {
             _library.PlayniteApi.Dialogs.ShowErrorMessage(Constants.SteamPathRequiredMessage, _library.Name);
@@ -161,7 +161,7 @@ internal class ImportExportService
     /// </summary>
     public void ShowAddToSteamDialog()
     {
-        var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+        var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_library.Settings.SelectedSteamUserId);
         if (string.IsNullOrWhiteSpace(vdfPath))
         {
             _library.PlayniteApi.Dialogs.ShowErrorMessage(Constants.SteamPathRequiredMessage, _library.Name);
@@ -268,7 +268,7 @@ internal class ImportExportService
     /// </summary>
     public void AddGamesToSteam(IEnumerable<Game> games)
     {
-        var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+        var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_library.Settings.SelectedSteamUserId);
         if (string.IsNullOrWhiteSpace(vdfPath))
         {
             _library.PlayniteApi.Dialogs.ShowErrorMessage(Constants.SteamPathRequiredMessage, _library.Name);
@@ -451,7 +451,7 @@ internal class ImportExportService
 
     private ExportResult AddGamesToSteamCore(IEnumerable<Game> games)
     {
-        var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+        var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_library.Settings.SelectedSteamUserId);
         if (string.IsNullOrWhiteSpace(vdfPath))
         {
             return new ExportResult();

--- a/src/SteamShortcutsImporter/PluginSettings.cs
+++ b/src/SteamShortcutsImporter/PluginSettings.cs
@@ -15,6 +15,7 @@ public class PluginSettings : ISettings
 
     public string SteamRootPath { get; set; } = string.Empty;
     public bool LaunchViaSteam { get; set; } = true;
+    public string? SelectedSteamUserId { get; set; } = null;
     public Dictionary<string, string> ExportMap { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
     public void BeginEdit() { }
@@ -49,12 +50,14 @@ public class PluginSettings : ISettings
             {
                 SteamRootPath = saved.SteamRootPath;
                 LaunchViaSteam = saved.LaunchViaSteam;
+                SelectedSteamUserId = saved.SelectedSteamUserId;
                 ExportMap = saved.ExportMap ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
             else
             {
                 SteamRootPath = GuessSteamRootPath() ?? string.Empty;
                 LaunchViaSteam = true;
+                SelectedSteamUserId = null;
                 ExportMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
         }
@@ -63,6 +66,7 @@ public class PluginSettings : ISettings
             LogManager.GetLogger().Error(ex, "Failed to load saved settings, falling back to defaults.");
             SteamRootPath = GuessSteamRootPath() ?? string.Empty;
             LaunchViaSteam = true;
+            SelectedSteamUserId = null;
             ExportMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
     }

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -44,7 +44,7 @@ public class ShortcutsLibrary : LibraryPlugin
         }
 
         _importExportService = new ImportExportService(this, _artworkManager, _pathResolver, _dialogBuilder, _backupManager);
-        _writeBackHandler = new WriteBackHandler(Logger, PlayniteApi, pluginId, _pathResolver, _artworkManager, _importExportService);
+        _writeBackHandler = new WriteBackHandler(Logger, PlayniteApi, pluginId, _pathResolver, _artworkManager, _importExportService, Settings);
     }
 
     public override void Dispose()
@@ -259,7 +259,7 @@ public class ShortcutsLibrary : LibraryPlugin
                 {
                     try
                     {
-                        var vdf = _pathResolver.ResolveShortcutsVdfPath();
+                        var vdf = _pathResolver.ResolveShortcutsVdfPathForUser(Settings.SelectedSteamUserId);
                         string? grid = null;
                         if (!string.IsNullOrEmpty(vdf))
                         {
@@ -287,7 +287,7 @@ public class ShortcutsLibrary : LibraryPlugin
     
     public override IEnumerable<GameMetadata> GetGames(LibraryGetGamesArgs args)
     {
-        var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+        var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(Settings.SelectedSteamUserId);
         if (string.IsNullOrWhiteSpace(vdfPath) || !File.Exists(vdfPath))
         {
             Logger.Warn($"shortcuts.vdf not found. SteamRootPath= '{Settings.SteamRootPath}' ResolvedVdf= '{vdfPath}'");

--- a/src/SteamShortcutsImporter/SteamUsersReader.cs
+++ b/src/SteamShortcutsImporter/SteamUsersReader.cs
@@ -1,0 +1,245 @@
+using Playnite.SDK;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SteamShortcutsImporter;
+
+/// <summary>
+/// Represents a Steam user account from loginusers.vdf.
+/// </summary>
+public class SteamUserAccount
+{
+    public string UserId { get; set; } = string.Empty;
+    public string AccountName { get; set; } = string.Empty;
+    public string DisplayName => string.IsNullOrEmpty(AccountName)
+        ? string.Format(Constants.SteamUserFallbackFormat, UserId)
+        : AccountName;
+}
+
+/// <summary>
+/// Reads Steam user accounts from config/loginusers.vdf (text VDF format).
+/// </summary>
+internal static class SteamUsersReader
+{
+    private static readonly ILogger Logger = LogManager.GetLogger();
+
+    /// <summary>
+    /// Reads loginusers.vdf and returns a mapping of userId to AccountName.
+    /// </summary>
+    /// <param name="steamRootPath">The Steam installation root path.</param>
+    /// <returns>Dictionary mapping Steam user IDs to account info.</returns>
+    public static Dictionary<string, SteamUserAccount> ReadUsers(string? steamRootPath)
+    {
+        var result = new Dictionary<string, SteamUserAccount>(StringComparer.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(steamRootPath))
+        {
+            return result;
+        }
+
+        var loginusersPath = Path.Combine(steamRootPath, "config", "loginusers.vdf");
+        if (!File.Exists(loginusersPath))
+        {
+            Logger.Debug($"loginusers.vdf not found at {loginusersPath}");
+            return result;
+        }
+
+        try
+        {
+            // Read with UTF-8 BOM detection
+            var content = File.ReadAllText(loginusersPath, Encoding.UTF8);
+            ParseLoginUsers(content, result);
+            Logger.Info($"Read {result.Count} user(s) from loginusers.vdf");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, $"Failed to read loginusers.vdf at {loginusersPath}");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the list of valid Steam users (intersection of loginusers.vdf and userdata directories).
+    /// </summary>
+    /// <param name="steamRootPath">The Steam installation root path.</param>
+    /// <param name="validUserIds">List of valid user IDs from userdata directories.</param>
+    /// <returns>List of SteamUserAccount objects for valid users.</returns>
+    public static List<SteamUserAccount> GetValidUsers(string? steamRootPath, IEnumerable<string> validUserIds)
+    {
+        var users = ReadUsers(steamRootPath);
+        var validIdSet = new HashSet<string>(validUserIds, StringComparer.Ordinal);
+        var result = new List<SteamUserAccount>();
+
+        foreach (var userId in validIdSet)
+        {
+            if (users.TryGetValue(userId, out var account))
+            {
+                result.Add(account);
+            }
+            else
+            {
+                // User has userdata folder but not in loginusers.vdf - add with fallback name
+                result.Add(new SteamUserAccount
+                {
+                    UserId = userId,
+                    AccountName = string.Empty
+                });
+            }
+        }
+
+        return result;
+    }
+
+    private static void ParseLoginUsers(string content, Dictionary<string, SteamUserAccount> result)
+    {
+        var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var currentUserId = string.Empty;
+        var currentUser = (SteamUserAccount?)null;
+        var inUsersBlock = false;
+        var inUserBlock = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+
+            // Skip empty lines and comments
+            if (string.IsNullOrEmpty(line) || line.StartsWith("//", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Look for "users" block
+            if (line.StartsWith("\"users\"", StringComparison.OrdinalIgnoreCase))
+            {
+                inUsersBlock = true;
+                continue;
+            }
+
+            if (!inUsersBlock)
+            {
+                continue;
+            }
+
+            // Opening brace for users block
+            if (line == "{")
+            {
+                if (!inUserBlock)
+                {
+                    // This is the users block opening brace
+                    continue;
+                }
+            }
+
+            // Closing brace
+            if (line == "}")
+            {
+                if (inUserBlock)
+                {
+                    // End of current user block
+                    if (currentUser != null && !string.IsNullOrEmpty(currentUserId))
+                    {
+                        result[currentUserId] = currentUser;
+                    }
+                    currentUserId = string.Empty;
+                    currentUser = null;
+                    inUserBlock = false;
+                }
+                else
+                {
+                    // End of users block
+                    inUsersBlock = false;
+                }
+                continue;
+            }
+
+            // Parse key-value pair: "key" "value"
+            var (key, value) = ParseKeyValue(line);
+            if (key == null)
+            {
+                continue;
+            }
+
+            // If the key is a Steam ID (numeric), it's a new user block
+            if (!inUserBlock && IsSteamId(key))
+            {
+                currentUserId = key;
+                currentUser = new SteamUserAccount { UserId = key };
+                inUserBlock = true;
+                continue;
+            }
+
+            // Parse user properties
+            if (inUserBlock && currentUser != null)
+            {
+                if (string.Equals(key, "AccountName", StringComparison.OrdinalIgnoreCase))
+                {
+                    currentUser.AccountName = value ?? string.Empty;
+                }
+            }
+        }
+    }
+
+    private static (string? key, string? value) ParseKeyValue(string line)
+    {
+        // Format: "key" "value" or "key" "value" // comment
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        foreach (var c in line)
+        {
+            if (c == '"')
+            {
+                if (inQuotes)
+                {
+                    parts.Add(current.ToString());
+                    current.Clear();
+                }
+                inQuotes = !inQuotes;
+            }
+            else if (inQuotes)
+            {
+                current.Append(c);
+            }
+            else if (c == '/' && parts.Count >= 2)
+            {
+                // Start of comment, stop parsing
+                break;
+            }
+        }
+
+        if (parts.Count >= 2)
+        {
+            return (parts[0], parts[1]);
+        }
+
+        if (parts.Count == 1)
+        {
+            return (parts[0], null);
+        }
+
+        return (null, null);
+    }
+
+    private static bool IsSteamId(string value)
+    {
+        // Steam IDs are 17-digit numbers (SteamID64)
+        if (string.IsNullOrEmpty(value) || value.Length != 17)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (!char.IsDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -17,6 +17,7 @@ internal class WriteBackHandler : IDisposable
     private readonly SteamPathResolver _pathResolver;
     private readonly ArtworkManager _artworkManager;
     private readonly ImportExportService _importExportService;
+    private readonly PluginSettings _settings;
 
     // Debouncing for Games_ItemUpdated to prevent race conditions
     private Timer? _updateDebounceTimer;
@@ -30,7 +31,8 @@ internal class WriteBackHandler : IDisposable
         Guid pluginId,
         SteamPathResolver pathResolver,
         ArtworkManager artworkManager,
-        ImportExportService importExportService)
+        ImportExportService importExportService,
+        PluginSettings settings)
     {
         _logger = logger;
         _playniteApi = playniteApi;
@@ -38,6 +40,7 @@ internal class WriteBackHandler : IDisposable
         _pathResolver = pathResolver;
         _artworkManager = artworkManager;
         _importExportService = importExportService;
+        _settings = settings;
 
         try
         {
@@ -90,7 +93,7 @@ internal class WriteBackHandler : IDisposable
         // Persist all pending changes from Playnite back to shortcuts.vdf
         try
         {
-            var vdfPath = _pathResolver.ResolveShortcutsVdfPath();
+            var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_settings.SelectedSteamUserId);
             if (string.IsNullOrWhiteSpace(vdfPath) || !File.Exists(vdfPath))
             {
                 return;

--- a/tests/ShortcutsTests/SteamUsersReaderTests.cs
+++ b/tests/ShortcutsTests/SteamUsersReaderTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace SteamShortcutsImporter.Tests;
+
+public class SteamUsersReaderTests
+{
+    [Fact]
+    public void ReadUsers_ValidLoginUsersVdf_ReturnsUsers()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            var loginusersContent = @"""users""
+{
+    ""12345678901234567""
+    {
+        ""AccountName""       ""testuser1""
+        ""PersonaName""       ""Test User 1""
+    }
+    ""98765432109876543""
+    {
+        ""AccountName""       ""testuser2""
+        ""PersonaName""       ""Test User 2""
+    }
+}";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            var result = SteamUsersReader.ReadUsers(tempRoot);
+
+            Assert.Equal(2, result.Count);
+            Assert.True(result.ContainsKey("12345678901234567"));
+            Assert.True(result.ContainsKey("98765432109876543"));
+            Assert.Equal("testuser1", result["12345678901234567"].AccountName);
+            Assert.Equal("testuser2", result["98765432109876543"].AccountName);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadUsers_NoLoginUsersFile_ReturnsEmpty()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(tempRoot);
+            // No config/loginusers.vdf created
+
+            var result = SteamUsersReader.ReadUsers(tempRoot);
+
+            Assert.Empty(result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadUsers_NullPath_ReturnsEmpty()
+    {
+        var result = SteamUsersReader.ReadUsers(null);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ReadUsers_EmptyPath_ReturnsEmpty()
+    {
+        var result = SteamUsersReader.ReadUsers("");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ReadUsers_MalformedVdf_ReturnsWhatItCan()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            var loginusersContent = @"""users""
+{
+    ""12345678901234567""
+    {
+        ""AccountName""       ""testuser""
+    }
+    // incomplete entry
+    ""99999999999999999""
+    {
+";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            var result = SteamUsersReader.ReadUsers(tempRoot);
+
+            // Should at least get the first user
+            Assert.Single(result);
+            Assert.True(result.ContainsKey("12345678901234567"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetValidUsers_WithMatchingUserIds_ReturnsMatchingUsers()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            var loginusersContent = @"""users""
+{
+    ""12345678901234567""
+    {
+        ""AccountName""       ""validuser""
+        ""PersonaName""       ""Valid User""
+    }
+    ""98765432109876543""
+    {
+        ""AccountName""       ""invaliduser""
+        ""PersonaName""       ""Invalid User""
+    }
+}";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            var validUserIds = new List<string> { "12345678901234567" };
+            var result = SteamUsersReader.GetValidUsers(tempRoot, validUserIds);
+
+            Assert.Single(result);
+            Assert.Equal("validuser", result[0].AccountName);
+            Assert.Equal("12345678901234567", result[0].UserId);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetValidUsers_UserIdNotInLoginUsers_ReturnsFallbackName()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            var loginusersContent = @"""users""
+{
+    ""12345678901234567""
+    {
+        ""AccountName""       ""testuser""
+    }
+}";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            // This user ID is not in loginusers.vdf but is valid IDs
+            var validUserIds = new List<string> { "99999999999999999" };
+            var result = SteamUsersReader.GetValidUsers(tempRoot, validUserIds);
+
+            Assert.Single(result);
+            Assert.Equal("", result[0].AccountName);
+            Assert.Equal("Steam User 99999999999999999", result[0].DisplayName);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetValidUsers_EmptyValidUserIds_ReturnsEmpty()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            var loginusersContent = @"""users""
+{
+    ""12345678901234567""
+    {
+        ""AccountName""       ""testuser""
+    }
+}";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            var result = SteamUsersReader.GetValidUsers(tempRoot, new List<string>());
+
+            Assert.Empty(result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+}
+
+public class SteamUserAccountTests
+{
+    [Fact]
+    public void DisplayName_WithAccountName_ReturnsAccountName()
+    {
+        var account = new SteamUserAccount
+        {
+            UserId = "12345678901234567",
+            AccountName = "testuser"
+        };
+
+        Assert.Equal("testuser", account.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_WithEmptyAccountName_ReturnsFallbackFormat()
+    {
+        var account = new SteamUserAccount
+        {
+            UserId = "12345678901234567",
+            AccountName = ""
+        };
+
+        Assert.Equal("Steam User 12345678901234567", account.DisplayName);
+    }
+}


### PR DESCRIPTION
## Summary
- Add ability to select which Steam account receives shortcuts in multi-account setups
- Previously, shortcuts were always added to the first account found, causing issues for users with multiple Steam accounts
- Fixes #12

## Changes
- **SelectedSteamUserId setting** - New persisted setting to store the user's preferred Steam account
- **SteamUsersReader** - New utility to parse `loginusers.vdf` and extract Steam usernames
- **ResolveShortcutsVdfPathForUser** - New method in path resolver to target specific user directories
- **ComboBox UI** - Settings page now shows a dropdown with all available Steam accounts
- **Updated sync operations** - All import/export operations now respect the selected user

## UI
The settings page now includes a "Default Steam user:" dropdown that shows:
- "(Auto-detect)" - Uses the first account found (previous behavior)
- List of all Steam accounts with their usernames

## Tests
- Added 10 tests for `SteamUsersReader` and `SteamUserAccount`
- Added 6 tests for `ResolveShortcutsVdfPathForUser`
- All 133 tests pass

## Screenshots
User can now select their preferred Steam account in settings, and all sync operations will target that account.

**Full Changelog**: https://github.com/hikaps/non-steam-sync/compare/develop...feat/steam-user-selection