### PR TITLE
fix(steam): filter out invalid user ID 0 and use PersonaName for display

### DIFF
--- a/src/SteamShortcutsImporter/BackupManager.cs
+++ b/src/SteamShortcutsImporter/BackupManager.cs
@@ -167,7 +167,14 @@ internal class BackupManager
             var root = _library.Settings.SteamRootPath;
             if (string.IsNullOrWhiteSpace(root)) return null;
 
-            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userId, Constants.ConfigDirectory, "shortcuts.vdf");
+            // Convert SteamID64 to userdata folder account ID
+            string userDataFolderId = userId;
+            if (Utils.TryConvertSteamId64ToUserDataId(userId, out var accountId))
+            {
+                userDataFolderId = accountId;
+            }
+
+            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userDataFolderId, Constants.ConfigDirectory, "shortcuts.vdf");
             return vdfPath;
         }
         catch (Exception ex)

--- a/src/SteamShortcutsImporter/Constants.cs
+++ b/src/SteamShortcutsImporter/Constants.cs
@@ -120,4 +120,5 @@ internal static class Constants
     public const string SteamUserLabel = "Default Steam user:";
     public const string AutoDetectUserLabel = "(Auto-detect)";
     public const string SteamUserFallbackFormat = "Steam User {0}";
+    public const ulong SteamId64Base = 76561197960265728UL;
 }

--- a/src/SteamShortcutsImporter/DuplicateUtils.cs
+++ b/src/SteamShortcutsImporter/DuplicateUtils.cs
@@ -9,14 +9,15 @@ internal static class DuplicateUtils
     /// Converts a path to its absolute form for comparison purposes.
     /// Removes surrounding quotes and resolves relative paths.
     /// </summary>
-    public static string GetAbsolutePath(string input)
+    public static string GetAbsolutePath(string? input)
     {
-        if (string.IsNullOrWhiteSpace(input)) return string.Empty;
-        var unq = input.Trim('"');
+        var normalizedInput = input ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalizedInput)) return string.Empty;
+        var unq = normalizedInput.Trim('"');
         try { return Path.GetFullPath(unq); } catch { return unq; }
     }
 
-    public static bool ArePathsEqual(string a, string b)
+    public static bool ArePathsEqual(string? a, string? b)
     {
         var an = GetAbsolutePath(a);
         var bn = GetAbsolutePath(b);
@@ -30,4 +31,3 @@ internal static class DuplicateUtils
         return $"steam://rungameid/{gid}";
     }
 }
-

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -59,18 +59,8 @@ internal class ImportExportService
                     return existsAny ? baseText + Constants.PlayniteTag : baseText;
                 },
                 previewImage: sc => _artworkManager.TryPickGridPreview(sc.AppId, gridDir),
-                isInitiallyChecked: sc =>
-                {
-                    var existsAny = detector.ExistsAnyGameMatch(sc);
-                    var isAlready = !string.IsNullOrEmpty(sc.StableId) && _library.PlayniteApi.Database.Games.Any(g => g.PluginId == _library.Id && string.Equals(g.GameId, sc.StableId, StringComparison.OrdinalIgnoreCase));
-                    return !isAlready && !existsAny;
-                },
-                isNew: sc =>
-                {
-                    var existsAny = detector.ExistsAnyGameMatch(sc);
-                    var isAlready = !string.IsNullOrEmpty(sc.StableId) && _library.PlayniteApi.Database.Games.Any(g => g.PluginId == _library.Id && string.Equals(g.GameId, sc.StableId, StringComparison.OrdinalIgnoreCase));
-                    return !isAlready && !existsAny;
-                },
+                isInitiallyChecked: ShouldImportShortcut,
+                isNew: ShouldImportShortcut,
                 confirmLabel: Constants.ImportConfirmLabel,
                 onConfirm: selected =>
                 {
@@ -78,6 +68,15 @@ internal class ImportExportService
                     var msg = skipped > 0 ? $"Imported {imported} item(s). Skipped {skipped} existing item(s)." : $"Imported {imported} item(s) from Steam.";
                     _library.PlayniteApi.Dialogs.ShowMessage(msg, _library.Name);
                 });
+
+            bool ShouldImportShortcut(SteamShortcut sc)
+            {
+                var existsAny = detector.ExistsAnyGameMatch(sc);
+                var isAlready = !string.IsNullOrEmpty(sc.StableId)
+                    && _library.PlayniteApi.Database.Games.Any(g => g.PluginId == _library.Id && string.Equals(g.GameId, sc.StableId, StringComparison.OrdinalIgnoreCase));
+
+                return !isAlready && !existsAny;
+            }
         }
         catch (Exception ex)
         {
@@ -248,7 +247,7 @@ internal class ImportExportService
 
                     if (res.WasSteamRunning)
                     {
-                        Logger.Info("Restarting Steam after export...");
+                        Logger.Debug("Restarting Steam after export...");
                         SteamProcessHelper.TryLaunchSteam(_library.Settings.SteamRootPath);
                     }
 
@@ -284,7 +283,7 @@ internal class ImportExportService
 
         if (res.WasSteamRunning)
         {
-            Logger.Info("Restarting Steam after export...");
+            Logger.Debug("Restarting Steam after export...");
             SteamProcessHelper.TryLaunchSteam(_library.Settings.SteamRootPath);
         }
 
@@ -459,14 +458,14 @@ internal class ImportExportService
 
         if (!ConfirmSteamRestart())
         {
-            Logger.Info("User cancelled export.");
+            Logger.Debug("User cancelled export.");
             return new ExportResult();
         }
 
         var wasSteamRunning = SteamProcessHelper.IsSteamRunning();
         if (wasSteamRunning)
         {
-            Logger.Info("Closing Steam before export...");
+            Logger.Debug("Closing Steam before export...");
             SteamProcessHelper.TryCloseSteam();
         }
 
@@ -496,7 +495,7 @@ internal class ImportExportService
                 skipped++;
                 var reason = GetSkipReason(g, result);
                 skippedGames.Add($"{g.Name}: {reason}");
-                Logger.Info($"Skipping '{g.Name}': {reason}");
+                Logger.Debug($"Skipping '{g.Name}': {reason}");
                 continue;
             }
 
@@ -505,7 +504,7 @@ internal class ImportExportService
             UpdateGameActions(g, appId, exePath, workDir, action);
         }
 
-        WriteShortcutsWithBackup(vdfPath!, shortcuts, context);
+        WriteShortcutsWithBackup(vdfPath!, shortcuts);
         return new ExportResult { Added = added, Updated = updated, Skipped = skipped, SkippedGames = skippedGames, WasSteamRunning = wasSteamRunning };
     }
 
@@ -555,7 +554,7 @@ internal class ImportExportService
             var result = BuildUrlActionResult(g, urlAction, existing, byPlayniteId);
             if (result.action != null)
             {
-                Logger.Info($"Using URL action for '{g.Name}': {urlAction.Path}");
+                Logger.Debug($"Using URL action for '{g.Name}': {urlAction.Path}");
                 return (result.exePath, result.workDir, result.name, result.action, ExeDiscoveryResult.Success);
             }
         }
@@ -650,8 +649,8 @@ internal class ImportExportService
             var workDir = !string.IsNullOrEmpty(g.InstallDirectory) && Directory.Exists(g.InstallDirectory) 
                 ? g.InstallDirectory 
                 : null;
-            
-            Logger.Info($"Creating URL shortcut for '{g.Name}': {url}");
+
+            Logger.Debug($"Creating URL shortcut for '{g.Name}': {url}");
             return (url, workDir, name, urlAction);
         }
 
@@ -733,8 +732,8 @@ internal class ImportExportService
             
             game.GameActions = new ObservableCollection<GameAction>(actions);
             _library.PlayniteApi.Database.Games.Update(game);
-            
-            Logger.Info($"Persisted new GameAction for '{game.Name}': {exePath}");
+
+            Logger.Debug($"Persisted new GameAction for '{game.Name}': {exePath}");
         }
         catch (Exception ex)
         {
@@ -849,7 +848,7 @@ internal class ImportExportService
             || val.StartsWith("steam://", StringComparison.OrdinalIgnoreCase);
     }
 
-    public void WriteShortcutsWithBackup(string vdfPath, List<SteamShortcut> shortcuts, ExportContext context)
+    public void WriteShortcutsWithBackup(string vdfPath, List<SteamShortcut> shortcuts)
     {
         try
         {

--- a/src/SteamShortcutsImporter/PluginSettingsView.cs
+++ b/src/SteamShortcutsImporter/PluginSettingsView.cs
@@ -418,7 +418,7 @@ public class PluginSettingsView : UserControl
         try
         {
             var steamPath = _pathBox?.Text;
-            var users = SteamUsersReader.GetValidUsers(steamPath, ShortcutsLibrary.GetSteamUserIdsStatic());
+            var users = SteamUsersReader.GetValidUsers(steamPath, ShortcutsLibrary.GetSteamUserIdsForPath(steamPath));
 
             _userComboBox.Items.Clear();
 

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -109,7 +109,8 @@ public class ShortcutsLibrary : LibraryPlugin
             {
                 var userId = Path.GetFileName(userDir);
                 // Filter out non-numeric directories (e.g., "ac" for anonymous)
-                if (!string.IsNullOrEmpty(userId) && userId.All(char.IsDigit))
+                // and "0" which is a system placeholder, not a real Steam user
+                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.All(char.IsDigit))
                 {
                     result.Add(userId);
                 }

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -96,29 +96,16 @@ public class ShortcutsLibrary : LibraryPlugin
     /// </summary>
     internal List<string> GetSteamUserIds()
     {
-        var result = new List<string>();
         try
         {
             var root = Settings.SteamRootPath;
-            if (string.IsNullOrWhiteSpace(root)) return result;
-
-            var userdata = Path.Combine(root, Constants.UserDataDirectory);
-            if (!Directory.Exists(userdata)) return result;
-
-            foreach (var userDir in Directory.EnumerateDirectories(userdata))
-            {
-                var userId = Path.GetFileName(userDir);
-                if (Utils.TryConvertUserDataIdToSteamId64(userId, out var steamId64) && steamId64 != "0")
-                {
-                    result.Add(steamId64);
-                }
-            }
+            return EnumerateSteamUserIdsFromRoot(root);
         }
         catch (Exception ex)
         {
             Logger.Warn(ex, "Failed to enumerate Steam user IDs.");
+            return new List<string>();
         }
-        return result;
     }
 
     /// <summary>
@@ -134,27 +121,40 @@ public class ShortcutsLibrary : LibraryPlugin
     /// </summary>
     internal static List<string> GetSteamUserIdsForPath(string? steamRootPath)
     {
-        var result = new List<string>();
-        if (string.IsNullOrWhiteSpace(steamRootPath)) return result;
-
         try
         {
-            var userdata = Path.Combine(steamRootPath, Constants.UserDataDirectory);
-            if (!Directory.Exists(userdata)) return result;
-
-            foreach (var userDir in Directory.EnumerateDirectories(userdata))
-            {
-                var userId = Path.GetFileName(userDir);
-                if (Utils.TryConvertUserDataIdToSteamId64(userId, out var steamId64) && steamId64 != "0")
-                {
-                    result.Add(steamId64);
-                }
-            }
+            return EnumerateSteamUserIdsFromRoot(steamRootPath);
         }
         catch (Exception ex)
         {
             Logger.Warn(ex, "Failed to enumerate Steam user IDs.");
+            return new List<string>();
         }
+    }
+
+    private static List<string> EnumerateSteamUserIdsFromRoot(string? steamRootPath)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(steamRootPath))
+        {
+            return result;
+        }
+
+        var userdata = Path.Combine(steamRootPath, Constants.UserDataDirectory);
+        if (!Directory.Exists(userdata))
+        {
+            return result;
+        }
+
+        foreach (var userDir in Directory.EnumerateDirectories(userdata))
+        {
+            var userId = Path.GetFileName(userDir);
+            if (Utils.TryConvertUserDataIdToSteamId64(userId, out var steamId64) && steamId64 != "0")
+            {
+                result.Add(steamId64);
+            }
+        }
+
         return result;
     }
 

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -108,11 +108,9 @@ public class ShortcutsLibrary : LibraryPlugin
             foreach (var userDir in Directory.EnumerateDirectories(userdata))
             {
                 var userId = Path.GetFileName(userDir);
-                // Filter out non-numeric directories (e.g., "ac" for anonymous),
-                // "0" (system placeholder), and non-17-digit IDs (not valid Steam64 IDs)
-                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.Length == 17 && userId.All(char.IsDigit))
+                if (Utils.TryConvertUserDataIdToSteamId64(userId, out var steamId64) && steamId64 != "0")
                 {
-                    result.Add(userId);
+                    result.Add(steamId64);
                 }
             }
         }
@@ -147,11 +145,9 @@ public class ShortcutsLibrary : LibraryPlugin
             foreach (var userDir in Directory.EnumerateDirectories(userdata))
             {
                 var userId = Path.GetFileName(userDir);
-                // Filter out non-numeric directories (e.g., "ac" for anonymous),
-                // "0" (system placeholder), and non-17-digit IDs (not valid Steam64 IDs)
-                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.Length == 17 && userId.All(char.IsDigit))
+                if (Utils.TryConvertUserDataIdToSteamId64(userId, out var steamId64) && steamId64 != "0")
                 {
-                    result.Add(userId);
+                    result.Add(steamId64);
                 }
             }
         }

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -108,9 +108,9 @@ public class ShortcutsLibrary : LibraryPlugin
             foreach (var userDir in Directory.EnumerateDirectories(userdata))
             {
                 var userId = Path.GetFileName(userDir);
-                // Filter out non-numeric directories (e.g., "ac" for anonymous)
-                // and "0" which is a system placeholder, not a real Steam user
-                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.All(char.IsDigit))
+                // Filter out non-numeric directories (e.g., "ac" for anonymous),
+                // "0" (system placeholder), and non-17-digit IDs (not valid Steam64 IDs)
+                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.Length == 17 && userId.All(char.IsDigit))
                 {
                     result.Add(userId);
                 }

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -132,6 +132,37 @@ public class ShortcutsLibrary : LibraryPlugin
     }
 
     /// <summary>
+    /// Gets all Steam user IDs from a specific Steam root path (static version for settings view).
+    /// </summary>
+    internal static List<string> GetSteamUserIdsForPath(string? steamRootPath)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(steamRootPath)) return result;
+
+        try
+        {
+            var userdata = Path.Combine(steamRootPath, Constants.UserDataDirectory);
+            if (!Directory.Exists(userdata)) return result;
+
+            foreach (var userDir in Directory.EnumerateDirectories(userdata))
+            {
+                var userId = Path.GetFileName(userDir);
+                // Filter out non-numeric directories (e.g., "ac" for anonymous),
+                // "0" (system placeholder), and non-17-digit IDs (not valid Steam64 IDs)
+                if (!string.IsNullOrEmpty(userId) && userId != "0" && userId.Length == 17 && userId.All(char.IsDigit))
+                {
+                    result.Add(userId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to enumerate Steam user IDs.");
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Gets the shortcuts.vdf path for a specific Steam user.
     /// </summary>
     internal string? GetShortcutsVdfPathForUser(string userId)

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -168,7 +168,14 @@ public class ShortcutsLibrary : LibraryPlugin
             var root = Settings.SteamRootPath;
             if (string.IsNullOrWhiteSpace(root)) return null;
 
-            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userId, Constants.ConfigDirectory, "shortcuts.vdf");
+            // Convert SteamID64 to userdata folder account ID
+            string userDataFolderId = userId;
+            if (Utils.TryConvertSteamId64ToUserDataId(userId, out var accountId))
+            {
+                userDataFolderId = accountId;
+            }
+
+            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userDataFolderId, Constants.ConfigDirectory, "shortcuts.vdf");
             return vdfPath;
         }
         catch (Exception ex)

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Threading;
 
 namespace SteamShortcutsImporter;
 
@@ -217,17 +216,6 @@ public class ShortcutsLibrary : LibraryPlugin
     {
         return Instance?.PlayniteApi;
     }
-
-    private void CreateManagedBackup(string sourceFilePath, string userId)
-    {
-        _backupManager.CreateManagedBackup(sourceFilePath, userId);
-    }
-
-    private static string? TryGetSteamUserFromPath(string path)
-    {
-        return BackupManager.TryGetSteamUserFromPath(path);
-    }
-
     public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)
     {
         yield return new MainMenuItem
@@ -331,7 +319,7 @@ public class ShortcutsLibrary : LibraryPlugin
 
         try
         {
-            Logger.Info($"Reading shortcuts from: {vdfPath}");
+            Logger.Debug($"Reading shortcuts from: {vdfPath}");
             var shortcuts = ShortcutsFile.Read(vdfPath!);
 
             var metas = new List<GameMetadata>();
@@ -375,7 +363,7 @@ public class ShortcutsLibrary : LibraryPlugin
                 seenIds.Add(chosenId);
             }
 
-            Logger.Info($"Imported {metas.Count} shortcuts as games.");
+            Logger.Debug($"Imported {metas.Count} shortcuts as games.");
             return metas;
         }
         catch (Exception ex)

--- a/src/SteamShortcutsImporter/SteamPathResolver.cs
+++ b/src/SteamShortcutsImporter/SteamPathResolver.cs
@@ -225,7 +225,7 @@ internal class SteamPathResolver
             var gogExe = TryParseGogManifest(game.InstallDirectory, game.GameId);
             if (!string.IsNullOrEmpty(gogExe) && File.Exists(gogExe))
             {
-                Logger.Info($"Found exe via GOG manifest for '{game.Name}': {gogExe}");
+                Logger.Debug($"Found exe via GOG manifest for '{game.Name}': {gogExe}");
                 return gogExe;
             }
 
@@ -240,7 +240,7 @@ internal class SteamPathResolver
             // 3. Single candidate - use it
             if (candidates.Count == 1)
             {
-                Logger.Info($"Auto-selected single exe for '{game.Name}': {candidates[0]}");
+                Logger.Debug($"Auto-selected single exe for '{game.Name}': {candidates[0]}");
                 return candidates[0];
             }
 
@@ -248,7 +248,7 @@ internal class SteamPathResolver
             var bestMatch = SelectBestExecutable(candidates, game.Name, game.InstallDirectory);
             if (bestMatch != null)
             {
-                Logger.Info($"Auto-selected best match for '{game.Name}': {bestMatch}");
+                Logger.Debug($"Auto-selected best match for '{game.Name}': {bestMatch}");
                 return bestMatch;
             }
 

--- a/src/SteamShortcutsImporter/SteamPathResolver.cs
+++ b/src/SteamShortcutsImporter/SteamPathResolver.cs
@@ -80,7 +80,15 @@ internal class SteamPathResolver
                 return null;
             }
 
-            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userId, Constants.ConfigDirectory, "shortcuts.vdf");
+            // Convert SteamID64 to userdata folder account ID
+            // userId may be a SteamID64 (17-digit) or already an account ID
+            string userDataFolderId = userId ?? string.Empty;
+            if (Utils.TryConvertSteamId64ToUserDataId(userId, out var accountId))
+            {
+                userDataFolderId = accountId;
+            }
+
+            var vdfPath = Path.Combine(root, Constants.UserDataDirectory, userDataFolderId, Constants.ConfigDirectory, "shortcuts.vdf");
             if (File.Exists(vdfPath))
             {
                 return vdfPath;
@@ -88,7 +96,7 @@ internal class SteamPathResolver
 
             // User's shortcuts.vdf doesn't exist yet - return the path anyway
             // (it will be created on export)
-            var userDir = Path.Combine(root, Constants.UserDataDirectory, userId);
+            var userDir = Path.Combine(root, Constants.UserDataDirectory, userDataFolderId);
             if (Directory.Exists(userDir))
             {
                 return vdfPath;

--- a/src/SteamShortcutsImporter/SteamProcessHelper.cs
+++ b/src/SteamShortcutsImporter/SteamProcessHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Playnite.SDK;
 
 namespace SteamShortcutsImporter;
 
@@ -10,6 +11,8 @@ namespace SteamShortcutsImporter;
 /// </summary>
 internal static class SteamProcessHelper
 {
+    private static readonly ILogger Logger = LogManager.GetLogger();
+
     /// <summary>
     /// Checks if the Steam client is currently running.
     /// </summary>
@@ -46,7 +49,7 @@ if (processes.Any())
         catch (Exception ex)
         {
             // If we can't determine, assume not running (fail safe)
-            Playnite.SDK.LogManager.GetLogger().Warn(ex, "Failed to check if Steam is running.");
+            Logger.Warn(ex, "Failed to check if Steam is running.");
             return false;
         }
     }
@@ -72,17 +75,15 @@ if (processes.Any())
     {
         try
         {
-            var logger = Playnite.SDK.LogManager.GetLogger();
-            
             // Check if Steam is running first
             if (!IsSteamRunning())
             {
-                logger.Info("Steam is not running, nothing to close.");
+                Logger.Debug("Steam is not running, nothing to close.");
                 return false;
             }
 
             // Use Windows taskkill command to force-close Steam
-            logger.Info("Closing Steam using taskkill /F /IM Steam.exe");
+            Logger.Debug("Closing Steam using taskkill /F /IM Steam.exe");
             
             var processStartInfo = new ProcessStartInfo
             {
@@ -98,7 +99,7 @@ if (processes.Any())
             {
                 if (process == null)
                 {
-                    logger.Warn("Failed to start taskkill process");
+                    Logger.Warn("Failed to start taskkill process");
                     return false;
                 }
 
@@ -109,15 +110,15 @@ if (processes.Any())
                 
                 if (!string.IsNullOrWhiteSpace(output))
                 {
-                    logger.Info($"taskkill output: {output}");
+                    Logger.Debug($"taskkill output: {output}");
                 }
                 
                 if (!string.IsNullOrWhiteSpace(error))
                 {
-                    logger.Warn($"taskkill error: {error}");
+                    Logger.Warn($"taskkill error: {error}");
                 }
                 
-                logger.Info($"taskkill exit code: {process.ExitCode}");
+                Logger.Debug($"taskkill exit code: {process.ExitCode}");
             }
             
             // Give Windows a moment to clean up the process
@@ -126,18 +127,18 @@ if (processes.Any())
             // Verify Steam closed
             if (IsSteamRunning())
             {
-                logger.Warn("Steam still running after taskkill");
+                Logger.Warn("Steam still running after taskkill");
                 return false;
             }
             else
             {
-                logger.Info("Steam closed successfully");
+                Logger.Debug("Steam closed successfully");
                 return true;
             }
         }
         catch (Exception ex)
         {
-            Playnite.SDK.LogManager.GetLogger().Warn(ex, "Failed to close Steam using taskkill");
+            Logger.Warn(ex, "Failed to close Steam using taskkill");
             return false;
         }
     }
@@ -151,13 +152,13 @@ if (processes.Any())
     {
         if (Environment.OSVersion.Platform != PlatformID.Win32NT)
         {
-            Playnite.SDK.LogManager.GetLogger().Info("Steam launch is only supported on Windows.");
+            Logger.Debug("Steam launch is only supported on Windows.");
             return false;
         }
 
         if (string.IsNullOrWhiteSpace(steamRootPath))
         {
-            Playnite.SDK.LogManager.GetLogger().Warn("Cannot launch Steam: Steam root path is null or empty.");
+            Logger.Warn("Cannot launch Steam: Steam root path is null or empty.");
             return false;
         }
 
@@ -167,17 +168,17 @@ if (processes.Any())
             
             if (!File.Exists(steamExePath))
             {
-                Playnite.SDK.LogManager.GetLogger().Warn($"Cannot launch Steam: Steam.exe not found at {steamExePath}");
+                Logger.Warn($"Cannot launch Steam: Steam.exe not found at {steamExePath}");
                 return false;
             }
 
             Process.Start(steamExePath);
-            Playnite.SDK.LogManager.GetLogger().Info($"Launched Steam from {steamExePath}");
+            Logger.Debug($"Launched Steam from {steamExePath}");
             return true;
         }
         catch (Exception ex)
         {
-            Playnite.SDK.LogManager.GetLogger().Error(ex, "Failed to launch Steam.");
+            Logger.Error(ex, "Failed to launch Steam.");
             return false;
         }
     }

--- a/src/SteamShortcutsImporter/SteamUsersReader.cs
+++ b/src/SteamShortcutsImporter/SteamUsersReader.cs
@@ -13,9 +13,15 @@ public class SteamUserAccount
 {
     public string UserId { get; set; } = string.Empty;
     public string AccountName { get; set; } = string.Empty;
-    public string DisplayName => string.IsNullOrEmpty(AccountName)
-        ? string.Format(Constants.SteamUserFallbackFormat, UserId)
-        : AccountName;
+    public string PersonaName { get; set; } = string.Empty;
+    /// <summary>
+    /// Display name prioritizes: PersonaName (Steam display name) > AccountName (login name) > fallback.
+    /// </summary>
+    public string DisplayName => !string.IsNullOrEmpty(PersonaName)
+        ? PersonaName
+        : !string.IsNullOrEmpty(AccountName)
+            ? AccountName
+            : string.Format(Constants.SteamUserFallbackFormat, UserId);
 }
 
 /// <summary>
@@ -177,6 +183,10 @@ internal static class SteamUsersReader
                 if (string.Equals(key, "AccountName", StringComparison.OrdinalIgnoreCase))
                 {
                     currentUser.AccountName = value ?? string.Empty;
+                }
+                else if (string.Equals(key, "PersonaName", StringComparison.OrdinalIgnoreCase))
+                {
+                    currentUser.PersonaName = value ?? string.Empty;
                 }
             }
         }

--- a/src/SteamShortcutsImporter/SteamUsersReader.cs
+++ b/src/SteamShortcutsImporter/SteamUsersReader.cs
@@ -58,6 +58,10 @@ internal static class SteamUsersReader
             var content = File.ReadAllText(loginusersPath, Encoding.UTF8);
             ParseLoginUsers(content, result);
             Logger.Info($"Read {result.Count} user(s) from loginusers.vdf");
+            foreach (var user in result.Values)
+            {
+                Logger.Debug($"User {user.UserId}: AccountName={user.AccountName ?? "(null)"}, PersonaName={user.PersonaName ?? "(null)"}, DisplayName={user.DisplayName}");
+            }
         }
         catch (Exception ex)
         {
@@ -88,6 +92,7 @@ internal static class SteamUsersReader
             else
             {
                 // User has userdata folder but not in loginusers.vdf - add with fallback name
+                Logger.Debug($"User {userId} not found in loginusers.vdf, using fallback name");
                 result.Add(new SteamUserAccount
                 {
                     UserId = userId,
@@ -96,6 +101,7 @@ internal static class SteamUsersReader
             }
         }
 
+        Logger.Info($"GetValidUsers: steamRootPath={steamRootPath ?? "(null)"}, validIds={validIdSet.Count}, readFromVdf={users.Count}, result={result.Count}");
         return result;
     }
 

--- a/src/SteamShortcutsImporter/SteamUsersReader.cs
+++ b/src/SteamShortcutsImporter/SteamUsersReader.cs
@@ -58,10 +58,6 @@ internal static class SteamUsersReader
             var content = File.ReadAllText(loginusersPath, Encoding.UTF8);
             ParseLoginUsers(content, result);
             Logger.Info($"Read {result.Count} user(s) from loginusers.vdf");
-            foreach (var user in result.Values)
-            {
-                Logger.Debug($"User {user.UserId}: AccountName={user.AccountName ?? "(null)"}, PersonaName={user.PersonaName ?? "(null)"}, DisplayName={user.DisplayName}");
-            }
         }
         catch (Exception ex)
         {
@@ -91,8 +87,6 @@ internal static class SteamUsersReader
             }
             else
             {
-                // User has userdata folder but not in loginusers.vdf - add with fallback name
-                Logger.Debug($"User {userId} not found in loginusers.vdf, using fallback name");
                 result.Add(new SteamUserAccount
                 {
                     UserId = userId,
@@ -100,8 +94,6 @@ internal static class SteamUsersReader
                 });
             }
         }
-
-        Logger.Info($"GetValidUsers: steamRootPath={steamRootPath ?? "(null)"}, validIds={validIdSet.Count}, readFromVdf={users.Count}, result={result.Count}");
         return result;
     }
 

--- a/src/SteamShortcutsImporter/Utils.cs
+++ b/src/SteamShortcutsImporter/Utils.cs
@@ -35,6 +35,37 @@ internal static class Utils
         steamId64 = converted.ToString();
         return true;
     }
+
+    /// <summary>
+    /// Converts a SteamID64 back to the userdata folder account ID.
+    /// </summary>
+    public static bool TryConvertSteamId64ToUserDataId(string? steamId64, out string userDataId)
+    {
+        userDataId = string.Empty;
+        if (string.IsNullOrWhiteSpace(steamId64))
+        {
+            return false;
+        }
+
+        var trimmed = steamId64!.Trim();
+        if (!ulong.TryParse(trimmed, out var steamId64Value))
+        {
+            return false;
+        }
+
+        // SteamID64 = SteamId64Base + AccountID
+        // AccountID = SteamID64 - SteamId64Base
+        if (steamId64Value < Constants.SteamId64Base)
+        {
+            // Already an account ID (short form)
+            userDataId = trimmed;
+            return true;
+        }
+
+        var accountId = steamId64Value - Constants.SteamId64Base;
+        userDataId = accountId.ToString();
+        return true;
+    }
     /// <summary>
     /// Normalizes a path by removing surrounding quotes and trimming whitespace.
     /// Used to ensure consistent path representation before hashing or comparison.

--- a/src/SteamShortcutsImporter/Utils.cs
+++ b/src/SteamShortcutsImporter/Utils.cs
@@ -1,10 +1,40 @@
 
+using System.Linq;
 using System.Text;
 
 namespace SteamShortcutsImporter;
 
 internal static class Utils
 {
+    public static bool TryConvertUserDataIdToSteamId64(string? userDataId, out string steamId64)
+    {
+        steamId64 = string.Empty;
+        if (string.IsNullOrWhiteSpace(userDataId))
+        {
+            return false;
+        }
+
+        var trimmed = userDataId!.Trim();
+        if (!trimmed.All(char.IsDigit))
+        {
+            return false;
+        }
+
+        if (trimmed.Length == 17)
+        {
+            steamId64 = trimmed;
+            return true;
+        }
+
+        if (!ulong.TryParse(trimmed, out var accountId))
+        {
+            return false;
+        }
+
+        var converted = Constants.SteamId64Base + accountId;
+        steamId64 = converted.ToString();
+        return true;
+    }
     /// <summary>
     /// Normalizes a path by removing surrounding quotes and trimming whitespace.
     /// Used to ensure consistent path representation before hashing or comparison.

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -130,8 +130,8 @@ internal class WriteBackHandler : IDisposable
 
             if (changed)
             {
-                _logger.Info($"Writing debounced updates to shortcuts.vdf for {ourGames.Count} game(s).");
-                _importExportService.WriteShortcutsWithBackup(vdfPath!, shortcuts, new ExportContext());
+                _logger.Debug($"Writing debounced updates to shortcuts.vdf for {ourGames.Count} game(s).");
+                _importExportService.WriteShortcutsWithBackup(vdfPath!, shortcuts);
             }
         }
         catch (Exception ex)
@@ -201,19 +201,16 @@ internal class WriteBackHandler : IDisposable
             {
                 game ??= new Game();
                 game.IsInstalled = true;
-                var newActions = new List<GameAction>();
-                
-                // If steam launch is enabled, add steam URL as primary and file action as secondary
-                if (true) // Assuming steam launch is enabled - this should be configurable
+                var newActions = new List<GameAction>
                 {
-                    newActions.Add(new GameAction
+                    new GameAction
                     {
                         Name = Constants.PlaySteamActionName,
                         Type = GameActionType.URL,
                         Path = expectedUrl,
                         IsPlayAction = true
-                    });
-                    newActions.Add(new GameAction
+                    },
+                    new GameAction
                     {
                         Name = Constants.PlayDirectActionName,
                         Type = GameActionType.File,
@@ -221,9 +218,9 @@ internal class WriteBackHandler : IDisposable
                         Arguments = sc.LaunchOptions,
                         WorkingDir = sc.StartDir,
                         IsPlayAction = false
-                    });
-                }
-                
+                    }
+                };
+
                 game.GameActions = new System.Collections.ObjectModel.ObservableCollection<GameAction>(newActions);
                 _playniteApi?.Database?.Games?.Update(game);
             }

--- a/tests/ShortcutsTests/DuplicateUtilsTests.cs
+++ b/tests/ShortcutsTests/DuplicateUtilsTests.cs
@@ -37,7 +37,7 @@ public class DuplicateUtilsTests
     [InlineData("")]
     [InlineData(null!)]
     [InlineData("   ")]
-    public void GetAbsolutePath_EmptyOrWhitespace_ReturnsEmpty(string input)
+    public void GetAbsolutePath_EmptyOrWhitespace_ReturnsEmpty(string? input)
     {
         Assert.Equal(string.Empty, DuplicateUtils.GetAbsolutePath(input));
     }

--- a/tests/ShortcutsTests/SteamUsersReaderTests.cs
+++ b/tests/ShortcutsTests/SteamUsersReaderTests.cs
@@ -38,6 +38,9 @@ public class SteamUsersReaderTests
             Assert.True(result.ContainsKey("98765432109876543"));
             Assert.Equal("testuser1", result["12345678901234567"].AccountName);
             Assert.Equal("testuser2", result["98765432109876543"].AccountName);
+            Assert.Equal("Test User 1", result["12345678901234567"].PersonaName);
+            Assert.Equal("Test User 2", result["98765432109876543"].PersonaName);
+            Assert.Equal("Test User 1", result["12345678901234567"].DisplayName);
         }
         finally
         {
@@ -213,6 +216,34 @@ public class SteamUsersReaderTests
                 Directory.Delete(tempRoot, recursive: true);
         }
     }
+
+    [Fact]
+    public void ReadUsers_RealWorldFormat_WithTabsAndExtraFields()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "steam_users_test_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var configDir = Path.Combine(tempRoot, "config");
+            Directory.CreateDirectory(configDir);
+
+            // Exact format from user's real loginusers.vdf with tabs
+            var loginusersContent = "\"users\"\n{\n\t\"76561198051525001\"\n\t{\n\t\t\"AccountName\"\t\t\"testuser1\"\n\t\t\"PersonaName\"\t\t\"Test Display 1\"\n\t\t\"RememberPassword\"\t\t\"1\"\n\t\t\"WantsOfflineMode\"\t\t\"0\"\n\t\t\"SkipOfflineModeWarning\"\t\t\"0\"\n\t\t\"AllowAutoLogin\"\t\t\"1\"\n\t\t\"MostRecent\"\t\t\"1\"\n\t\t\"Timestamp\"\t\t\"1772589956\"\n\t}\n\t\"76561198391833687\"\n\t{\n\t\t\"AccountName\"\t\t\"testuser2\"\n\t\t\"PersonaName\"\t\t\"Test Display 2\"\n\t\t\"RememberPassword\"\t\t\"1\"\n\t\t\"WantsOfflineMode\"\t\t\"0\"\n\t\t\"SkipOfflineModeWarning\"\t\t\"0\"\n\t\t\"AllowAutoLogin\"\t\t\"0\"\n\t\t\"MostRecent\"\t\t\"0\"\n\t\t\"Timestamp\"\t\t\"1771962844\"\n\t}\n}";
+            File.WriteAllText(Path.Combine(configDir, "loginusers.vdf"), loginusersContent);
+
+            var result = SteamUsersReader.ReadUsers(tempRoot);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal("testuser1", result["76561198051525001"].AccountName);
+            Assert.Equal("Test Display 1", result["76561198051525001"].PersonaName);
+            Assert.Equal("Test Display 1", result["76561198051525001"].DisplayName);
+            Assert.Equal("Test Display 2", result["76561198391833687"].DisplayName);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
 }
 
 public class SteamUserAccountTests
@@ -239,5 +270,32 @@ public class SteamUserAccountTests
         };
 
         Assert.Equal("Steam User 12345678901234567", account.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_WithPersonaName_ReturnsPersonaName()
+    {
+        var account = new SteamUserAccount
+        {
+            UserId = "12345678901234567",
+            AccountName = "loginname",
+            PersonaName = "Display Name"
+        };
+
+        Assert.Equal("Display Name", account.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_PersonaNameOverridesAccountName()
+    {
+        var account = new SteamUserAccount
+        {
+            UserId = "12345678901234567",
+            AccountName = "loginname",
+            PersonaName = "Friendly Name"
+        };
+
+        // PersonaName should take priority over AccountName
+        Assert.Equal("Friendly Name", account.DisplayName);
     }
 }

--- a/tests/ShortcutsTests/UtilsTests.cs
+++ b/tests/ShortcutsTests/UtilsTests.cs
@@ -48,7 +48,7 @@ public class UtilsTests
     [InlineData("\"C:\\Path\"", "C:\\Path")]
     [InlineData("/home/user/game", "/home/user/game")]
     [InlineData("\"/home/user/game\"", "/home/user/game")]
-    public void NormalizePath_HandlesQuotesAndWhitespace(string input, string expected)
+    public void NormalizePath_HandlesQuotesAndWhitespace(string? input, string expected)
     {
         Assert.Equal(expected, Utils.NormalizePath(input));
     }

--- a/tests/ShortcutsTests/UtilsTests.cs
+++ b/tests/ShortcutsTests/UtilsTests.cs
@@ -5,11 +5,42 @@ namespace SteamShortcutsImporter.Tests;
 
 public class UtilsTests
 {
+    [Fact]
+    public void TryConvertUserDataIdToSteamId64_WithSteamId64_ReturnsSameValue()
+    {
+        var input = "76561198051525001";
+
+        var result = Utils.TryConvertUserDataIdToSteamId64(input, out var steamId64);
+
+        Assert.True(result);
+        Assert.Equal("76561198051525001", steamId64);
+    }
+
+    [Fact]
+    public void TryConvertUserDataIdToSteamId64_WithAccountId_ReturnsSteamId64()
+    {
+        var result = Utils.TryConvertUserDataIdToSteamId64("258645", out var steamId64);
+
+        Assert.True(result);
+        Assert.Equal("76561197960524373", steamId64);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("ac")]
+    [InlineData("1234abc")]
+    public void TryConvertUserDataIdToSteamId64_WithInvalidInput_ReturnsFalse(string input)
+    {
+        var result = Utils.TryConvertUserDataIdToSteamId64(input, out var steamId64);
+
+        Assert.False(result);
+        Assert.Equal(string.Empty, steamId64);
+    }
     [Theory]
     [InlineData("\"C:\\Games\\Foo.exe\"", "C:\\Games\\Foo.exe")]
     [InlineData("C:\\Games\\Foo.exe", "C:\\Games\\Foo.exe")]
     [InlineData("  C:\\Games\\Foo.exe  ", "C:\\Games\\Foo.exe")]
-    [InlineData("\"  C:\\Games\\Foo.exe  \"", "  C:\\Games\\Foo.exe  ")]  // Quotes removed first, then inner spaces preserved
+    [InlineData("\"  C:\\Games\\Foo.exe  \"", "  C:\\Games\\Foo.exe  ")]
     [InlineData("", "")]
     [InlineData(null!, "")]
     [InlineData("   ", "")]


### PR DESCRIPTION
## Summary

Addresses feedback from #13 comment:
- Fixes "Steam User 0" appearing as an invalid option in the user dropdown
- Improves user display names by reading `PersonaName` from `loginusers.vdf`

## Changes

- **Filter out user ID "0"**: The `userdata/0/` directory is a system placeholder, not a real Steam user. It's now excluded from the user list.
- **Read PersonaName**: Added parsing of `PersonaName` field from Steam's `loginusers.vdf`
- **Improved DisplayName priority**: `PersonaName` (Steam display name) → `AccountName` (login name) → fallback

## Testing

- Build: ✓ Success
- Tests: ✓ 133 passed