### PR TITLE
feat(steam): add emulator support for game exports

### DIFF
--- a/src/SteamShortcutsImporter/EmulatorPathUtils.cs
+++ b/src/SteamShortcutsImporter/EmulatorPathUtils.cs
@@ -31,12 +31,20 @@ internal static class EmulatorPathUtils
             return string.Empty;
         }
 
-        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
+        // Already quoted
+        if (trimmed.StartsWith("\"") && trimmed.EndsWith("\""))
         {
             return trimmed;
         }
 
-        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
+        // No spaces - no need to quote
+        if (!trimmed.Contains(" "))
+        {
+            return trimmed;
+        }
+
+        // Looks like flags or already has quoted parts - don't re-quote
+        if (trimmed.StartsWith("-") || trimmed.StartsWith("\""))
         {
             return trimmed;
         }

--- a/src/SteamShortcutsImporter/EmulatorPathUtils.cs
+++ b/src/SteamShortcutsImporter/EmulatorPathUtils.cs
@@ -1,0 +1,88 @@
+using Playnite.SDK;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace SteamShortcutsImporter;
+
+internal static class EmulatorPathUtils
+{
+    public static bool IsRegexPattern(string? s)
+    {
+        if (string.IsNullOrEmpty(s))
+        {
+            return false;
+        }
+
+        var value = s ?? string.Empty;
+        return value.StartsWith("^") || value.EndsWith("$") || value.Contains("\\.") || value.Contains(".*");
+    }
+
+    public static string QuoteArgumentsIfNeeded(string? args)
+    {
+        if (args == null)
+        {
+            return string.Empty;
+        }
+
+        var trimmed = args.Trim();
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
+        {
+            return trimmed;
+        }
+
+        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
+        {
+            return trimmed;
+        }
+
+        return "\"" + trimmed + "\"";
+    }
+
+    public static string? ResolveExecutablePattern(string pattern, string? emulatorDir, ILogger logger, string gameName)
+    {
+        if (string.IsNullOrEmpty(emulatorDir) || !Directory.Exists(emulatorDir))
+        {
+            logger.Warn($"Cannot resolve emulator pattern for '{gameName}': Emulator directory not found ({emulatorDir})");
+            return null;
+        }
+
+        try
+        {
+            var regexPattern = pattern;
+            if (!regexPattern.StartsWith("^"))
+            {
+                regexPattern = "^" + regexPattern;
+            }
+
+            if (!regexPattern.EndsWith("$"))
+            {
+                regexPattern += "$";
+            }
+
+            var regex = new Regex(regexPattern, RegexOptions.IgnoreCase);
+            foreach (var file in Directory.EnumerateFiles(emulatorDir, "*.exe", SearchOption.TopDirectoryOnly))
+            {
+                var fileName = Path.GetFileName(file);
+                if (regex.IsMatch(fileName))
+                {
+                    logger.Info($"Resolved emulator pattern '{pattern}' to '{file}' for '{gameName}'");
+                    return file;
+                }
+            }
+
+            logger.Warn($"Cannot export '{gameName}': No executable matching pattern '{pattern}' found in {emulatorDir}");
+        }
+        catch (Exception ex)
+        {
+            logger.Warn(ex, $"Failed to resolve emulator pattern '{pattern}' for '{gameName}'");
+        }
+
+        return null;
+    }
+}

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -1157,8 +1157,6 @@ internal class ImportExportService
         ShortcutsFile.Write(vdfPath, shortcuts);
     }
 
-    #region Nested Classes
-
     private sealed class ExportResult 
     { 
         public int Added; 
@@ -1196,6 +1194,4 @@ internal class ImportExportService
         public bool ShouldSelect => HasPlayableAction && !ExistsInSteam;
         public bool IsNew => ShouldSelect;
     }
-
-    #endregion
 }

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -757,6 +757,17 @@ internal class ImportExportService
     {
         // Get executable path
         var exePath = profile.Executable ?? string.Empty;
+
+        // Resolve regex patterns to actual file paths
+        if (IsRegexPattern(exePath))
+        {
+            exePath = ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
+            if (string.IsNullOrEmpty(exePath))
+            {
+                return (string.Empty, null, name, null);
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(exePath))
         {
             logger.Warn($"Cannot export '{g.Name}': Emulator profile has no executable set");
@@ -784,6 +795,7 @@ internal class ImportExportService
         var emulatorDir = emulatorInstallDir ?? string.Empty;
         var expandedExe = expandVariables(g, exePath, emulatorDir);
         var expandedArgs = expandVariables(g, args, emulatorDir);
+        expandedArgs = QuoteArgumentsIfNeeded(expandedArgs);
 
         // Get working directory
         string? workDir = profile.WorkingDirectory;
@@ -859,6 +871,17 @@ internal class ImportExportService
 
         // Get executable from the definition
         var exePath = profileDef.StartupExecutable ?? string.Empty;
+
+        // Resolve regex patterns to actual file paths
+        if (IsRegexPattern(exePath))
+        {
+            exePath = ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
+            if (string.IsNullOrEmpty(exePath))
+            {
+                return (string.Empty, null, name, null);
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(exePath))
         {
             logger.Warn($"Cannot export '{g.Name}': Built-in emulator profile has no startup executable");
@@ -899,6 +922,7 @@ internal class ImportExportService
         var emulatorDir = emulatorInstallDir ?? string.Empty;
         var expandedExe = expandVariables(g, exePath, emulatorDir);
         var expandedArgs = expandVariables(g, args, emulatorDir);
+        expandedArgs = QuoteArgumentsIfNeeded(expandedArgs);
 
         // Working directory - use emulator install dir if not specified
         string? workDir = emulatorInstallDir;
@@ -1124,6 +1148,87 @@ internal class ImportExportService
 
         ShortcutsFile.Write(vdfPath, shortcuts);
     }
+
+    #region Emulator Pattern Resolution
+
+    /// <summary>
+    /// Detects if a string looks like a regex pattern (rather than a literal file path).
+    /// </summary>
+    private static bool IsRegexPattern(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return false;
+
+        // Check for regex-specific patterns:
+        // - ^ (start anchor)
+        // - $ (end anchor)
+        // - \\. (escaped dot, not just \\ which is in Windows paths)
+        // - .* (wildcard)
+        return s.StartsWith("^") || s.EndsWith("$") || s.Contains("\\.") || s.Contains(".*");
+    }
+
+    private static string QuoteArgumentsIfNeeded(string? args)
+    {
+        if (string.IsNullOrWhiteSpace(args)) return args ?? string.Empty;
+
+        var trimmed = args.Trim();
+        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
+        {
+            return trimmed;
+        }
+
+        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
+        {
+            return trimmed;
+        }
+
+        return "\"" + trimmed + "\"";
+    }
+
+    /// <summary>
+    /// Resolves a regex pattern to an actual executable file by matching against files in the emulator directory.
+    /// </summary>
+    private static string? ResolveExecutablePattern(string pattern, string? emulatorDir, ILogger logger, string gameName)
+    {
+        if (string.IsNullOrEmpty(emulatorDir) || !Directory.Exists(emulatorDir))
+        {
+            logger.Warn($"Cannot resolve emulator pattern for '{gameName}': Emulator directory not found ({emulatorDir})");
+            return null;
+        }
+
+        try
+        {
+            // Convert regex pattern to match against filenames
+            // Pattern like "^sameboy\\.exe$" should match "sameboy.exe"
+            var regexPattern = pattern;
+
+            // Ensure pattern has anchors for matching
+            if (!regexPattern.StartsWith("^")) regexPattern = "^" + regexPattern;
+            if (!regexPattern.EndsWith("$")) regexPattern = regexPattern + "$";
+
+            var regex = new System.Text.RegularExpressions.Regex(regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            // Scan for matching executables in the emulator directory
+            foreach (var file in Directory.EnumerateFiles(emulatorDir, "*.exe", SearchOption.TopDirectoryOnly))
+            {
+                var fileName = Path.GetFileName(file);
+                if (regex.IsMatch(fileName))
+                {
+                    logger.Info($"Resolved emulator pattern '{pattern}' to '{file}' for '{gameName}'");
+                    return file;
+                }
+            }
+
+            logger.Warn($"Cannot export '{gameName}': No executable matching pattern '{pattern}' found in {emulatorDir}");
+        }
+        catch (Exception ex)
+        {
+            logger.Warn(ex, $"Failed to resolve emulator pattern '{pattern}' for '{gameName}'");
+        }
+
+        return null;
+    }
+
+    #endregion
 
     #region Nested Classes
 

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -674,19 +674,28 @@ internal class ImportExportService
     /// Builds the result tuple for an emulator-based game action.
     /// Resolves the emulator profile to get the executable path, arguments, and working directory.
     /// </summary>
-    private (string exePath, string? workDir, string name, GameAction? action) BuildEmulatorActionResult(
+    internal (string exePath, string? workDir, string name, GameAction? action) BuildEmulatorActionResult(
+        Game g,
+        GameAction emulatorAction)
+    {
+        return BuildEmulatorActionResult(_library.PlayniteApi, Logger, g, emulatorAction);
+    }
+
+    internal static (string exePath, string? workDir, string name, GameAction? action) BuildEmulatorActionResult(
+        IPlayniteAPI playniteApi,
+        ILogger logger,
         Game g,
         GameAction emulatorAction)
     {
         var name = string.IsNullOrEmpty(g.Name) ? "Emulator Game" : g.Name;
 
         // Get emulator from database
-        var emulator = _library.PlayniteApi.Database.Emulators
+        var emulator = playniteApi.Database.Emulators
             .FirstOrDefault(e => e.Id == emulatorAction.EmulatorId);
 
         if (emulator == null)
         {
-            Logger.Warn($"Cannot export '{g.Name}': Emulator not found (EmulatorId={emulatorAction.EmulatorId})");
+            logger.Warn($"Cannot export '{g.Name}': Emulator not found (EmulatorId={emulatorAction.EmulatorId})");
             return (string.Empty, null, name, null);
         }
 
@@ -694,30 +703,42 @@ internal class ImportExportService
         var profile = emulator.GetProfile(emulatorAction.EmulatorProfileId);
         if (profile == null)
         {
-            Logger.Warn($"Cannot export '{g.Name}': Emulator profile not found (ProfileId={emulatorAction.EmulatorProfileId})");
+            logger.Warn($"Cannot export '{g.Name}': Emulator profile not found (ProfileId={emulatorAction.EmulatorProfileId})");
             return (string.Empty, null, name, null);
         }
 
         // Handle CustomEmulatorProfile
         if (profile is CustomEmulatorProfile customProfile)
         {
-            return BuildCustomEmulatorResult(g, emulatorAction, customProfile, emulator.InstallDir, name);
+            return BuildCustomEmulatorResult(playniteApi, logger, g, emulatorAction, customProfile, emulator.InstallDir, name);
         }
 
         // Handle BuiltInEmulatorProfile
         if (profile is BuiltInEmulatorProfile builtInProfile)
         {
-            return BuildBuiltInEmulatorResult(g, emulatorAction, builtInProfile, emulator.InstallDir, emulator.BuiltInConfigId, name);
+            return BuildBuiltInEmulatorResult(playniteApi, logger, playniteApi.Emulation, g, emulatorAction, builtInProfile, emulator.InstallDir, emulator.BuiltInConfigId, name);
         }
 
-        Logger.Warn($"Cannot export '{g.Name}': Unknown emulator profile type '{profile.GetType().Name}'");
+        logger.Warn($"Cannot export '{g.Name}': Unknown emulator profile type '{profile.GetType().Name}'");
         return (string.Empty, null, name, null);
     }
 
     /// <summary>
     /// Builds result for a custom emulator profile.
     /// </summary>
-    private (string exePath, string? workDir, string name, GameAction? action) BuildCustomEmulatorResult(
+    internal (string exePath, string? workDir, string name, GameAction? action) BuildCustomEmulatorResult(
+        Game g,
+        GameAction emulatorAction,
+        CustomEmulatorProfile profile,
+        string? emulatorInstallDir,
+        string name)
+    {
+        return BuildCustomEmulatorResult(_library.PlayniteApi, Logger, g, emulatorAction, profile, emulatorInstallDir, name);
+    }
+
+    internal static (string exePath, string? workDir, string name, GameAction? action) BuildCustomEmulatorResult(
+        IPlayniteAPI playniteApi,
+        ILogger logger,
         Game g,
         GameAction emulatorAction,
         CustomEmulatorProfile profile,
@@ -728,7 +749,7 @@ internal class ImportExportService
         var exePath = profile.Executable ?? string.Empty;
         if (string.IsNullOrWhiteSpace(exePath))
         {
-            Logger.Warn($"Cannot export '{g.Name}': Emulator profile has no executable set");
+            logger.Warn($"Cannot export '{g.Name}': Emulator profile has no executable set");
             return (string.Empty, null, name, null);
         }
 
@@ -744,30 +765,25 @@ internal class ImportExportService
             // Combine profile arguments with action's additional arguments
             var profileArgs = profile.Arguments ?? string.Empty;
             var additionalArgs = emulatorAction.AdditionalArguments ?? string.Empty;
-            args = string.IsNullOrWhiteSpace(additionalArgs) 
-                ? profileArgs 
+            args = string.IsNullOrWhiteSpace(additionalArgs)
+                ? profileArgs
                 : (string.IsNullOrWhiteSpace(profileArgs) ? additionalArgs : $"{profileArgs} {additionalArgs}");
         }
 
         // Expand variables using Playnite API
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = _library.PlayniteApi.ExpandGameVariables(g, exePath, emulatorDir);
-        var expandedArgs = _library.PlayniteApi.ExpandGameVariables(g, args, emulatorDir);
+        var expandedExe = playniteApi.ExpandGameVariables(g, exePath, emulatorDir);
+        var expandedArgs = playniteApi.ExpandGameVariables(g, args, emulatorDir);
 
         // Get working directory
         string? workDir = profile.WorkingDirectory;
         if (!string.IsNullOrWhiteSpace(workDir))
         {
-            workDir = _library.PlayniteApi.ExpandGameVariables(g, workDir, emulatorDir);
+            workDir = playniteApi.ExpandGameVariables(g, workDir, emulatorDir);
         }
 
-        // For Steam shortcut, we need to combine exe + args into a launch command
-        // Store args separately for the shortcut's LaunchOptions
-        // The exePath is used as-is, and args go into LaunchOptions in CreateOrUpdateShortcut
+        logger.Info($"Resolved emulator for '{g.Name}': Exe={expandedExe}, Args={expandedArgs}");
 
-        Logger.Info($"Resolved emulator for '{g.Name}': Exe={expandedExe}, Args={expandedArgs}");
-
-        // We need to store the arguments somewhere since CreateOrUpdateShortcut reads from action.Arguments
         // Create a synthetic File action with the resolved paths
         var syntheticAction = new GameAction
         {
@@ -786,7 +802,21 @@ internal class ImportExportService
     /// Builds result for a built-in emulator profile.
     /// Built-in profiles use definitions from Playnite's emulator database.
     /// </summary>
-    private (string exePath, string? workDir, string name, GameAction? action) BuildBuiltInEmulatorResult(
+    internal (string exePath, string? workDir, string name, GameAction? action) BuildBuiltInEmulatorResult(
+        Game g,
+        GameAction emulatorAction,
+        BuiltInEmulatorProfile profile,
+        string? emulatorInstallDir,
+        string? builtInConfigId,
+        string name)
+    {
+        return BuildBuiltInEmulatorResult(_library.PlayniteApi, Logger, _library.PlayniteApi.Emulation, g, emulatorAction, profile, emulatorInstallDir, builtInConfigId, name);
+    }
+
+    internal static (string exePath, string? workDir, string name, GameAction? action) BuildBuiltInEmulatorResult(
+        IPlayniteAPI playniteApi,
+        ILogger logger,
+        IEmulationAPI emulationApi,
         Game g,
         GameAction emulatorAction,
         BuiltInEmulatorProfile profile,
@@ -797,15 +827,15 @@ internal class ImportExportService
         // Built-in profiles reference an emulator definition via the emulator's BuiltInConfigId
         if (string.IsNullOrEmpty(builtInConfigId))
         {
-            Logger.Warn($"Cannot export '{g.Name}': Emulator has no BuiltInConfigId set");
+            logger.Warn($"Cannot export '{g.Name}': Emulator has no BuiltInConfigId set");
             return (string.Empty, null, name, null);
         }
 
         // Get the emulator definition from Playnite's emulation database
-        var definition = _library.PlayniteApi.Emulation.GetEmulator(builtInConfigId);
+        var definition = emulationApi.GetEmulator(builtInConfigId);
         if (definition == null)
         {
-            Logger.Warn($"Cannot export '{g.Name}': Built-in emulator definition not found (Id={builtInConfigId})");
+            logger.Warn($"Cannot export '{g.Name}': Built-in emulator definition not found (Id={builtInConfigId})");
             return (string.Empty, null, name, null);
         }
 
@@ -813,7 +843,7 @@ internal class ImportExportService
         var profileDef = definition.Profiles?.FirstOrDefault(p => p.Name == profile.BuiltInProfileName);
         if (profileDef == null)
         {
-            Logger.Warn($"Cannot export '{g.Name}': Built-in emulator profile definition not found (Profile={profile.BuiltInProfileName})");
+            logger.Warn($"Cannot export '{g.Name}': Built-in emulator profile definition not found (Profile={profile.BuiltInProfileName})");
             return (string.Empty, null, name, null);
         }
 
@@ -821,7 +851,7 @@ internal class ImportExportService
         var exePath = profileDef.StartupExecutable ?? string.Empty;
         if (string.IsNullOrWhiteSpace(exePath))
         {
-            Logger.Warn($"Cannot export '{g.Name}': Built-in emulator profile has no startup executable");
+            logger.Warn($"Cannot export '{g.Name}': Built-in emulator profile has no startup executable");
             return (string.Empty, null, name, null);
         }
 
@@ -843,7 +873,7 @@ internal class ImportExportService
             var builtInArgs = profileDef.StartupArguments ?? string.Empty;
             var customArgs = profile.CustomArguments ?? string.Empty;
             var additionalArgs = emulatorAction.AdditionalArguments ?? string.Empty;
-            
+
             args = builtInArgs;
             if (!string.IsNullOrWhiteSpace(customArgs))
             {
@@ -857,13 +887,13 @@ internal class ImportExportService
 
         // Expand variables
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = _library.PlayniteApi.ExpandGameVariables(g, exePath, emulatorDir);
-        var expandedArgs = _library.PlayniteApi.ExpandGameVariables(g, args, emulatorDir);
+        var expandedExe = playniteApi.ExpandGameVariables(g, exePath, emulatorDir);
+        var expandedArgs = playniteApi.ExpandGameVariables(g, args, emulatorDir);
 
         // Working directory - use emulator install dir if not specified
         string? workDir = emulatorInstallDir;
 
-        Logger.Info($"Resolved built-in emulator for '{g.Name}': Exe={expandedExe}, Args={expandedArgs}");
+        logger.Info($"Resolved built-in emulator for '{g.Name}': Exe={expandedExe}, Args={expandedArgs}");
 
         // Create a synthetic File action with the resolved paths
         var syntheticAction = new GameAction

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -687,11 +687,21 @@ internal class ImportExportService
         Game g,
         GameAction emulatorAction)
     {
+        return BuildEmulatorActionResult(playniteApi.Database.Emulators, playniteApi.Emulation, playniteApi.ExpandGameVariables, logger, g, emulatorAction);
+    }
+
+    internal static (string exePath, string? workDir, string name, GameAction? action) BuildEmulatorActionResult(
+        IEnumerable<Emulator> emulators,
+        IEmulationAPI emulationApi,
+        Func<Game, string, string, string> expandVariables,
+        ILogger logger,
+        Game g,
+        GameAction emulatorAction)
+    {
         var name = string.IsNullOrEmpty(g.Name) ? "Emulator Game" : g.Name;
 
         // Get emulator from database
-        var emulator = playniteApi.Database.Emulators
-            .FirstOrDefault(e => e.Id == emulatorAction.EmulatorId);
+        var emulator = emulators.FirstOrDefault(e => e.Id == emulatorAction.EmulatorId);
 
         if (emulator == null)
         {
@@ -710,13 +720,13 @@ internal class ImportExportService
         // Handle CustomEmulatorProfile
         if (profile is CustomEmulatorProfile customProfile)
         {
-            return BuildCustomEmulatorResult(playniteApi, logger, g, emulatorAction, customProfile, emulator.InstallDir, name);
+            return BuildCustomEmulatorResult(expandVariables, logger, g, emulatorAction, customProfile, emulator.InstallDir, name);
         }
 
         // Handle BuiltInEmulatorProfile
         if (profile is BuiltInEmulatorProfile builtInProfile)
         {
-            return BuildBuiltInEmulatorResult(playniteApi, logger, playniteApi.Emulation, g, emulatorAction, builtInProfile, emulator.InstallDir, emulator.BuiltInConfigId, name);
+            return BuildBuiltInEmulatorResult(expandVariables, logger, emulationApi, g, emulatorAction, builtInProfile, emulator.InstallDir, emulator.BuiltInConfigId, name);
         }
 
         logger.Warn($"Cannot export '{g.Name}': Unknown emulator profile type '{profile.GetType().Name}'");
@@ -733,11 +743,11 @@ internal class ImportExportService
         string? emulatorInstallDir,
         string name)
     {
-        return BuildCustomEmulatorResult(_library.PlayniteApi, Logger, g, emulatorAction, profile, emulatorInstallDir, name);
+        return BuildCustomEmulatorResult(_library.PlayniteApi.ExpandGameVariables, Logger, g, emulatorAction, profile, emulatorInstallDir, name);
     }
 
     internal static (string exePath, string? workDir, string name, GameAction? action) BuildCustomEmulatorResult(
-        IPlayniteAPI playniteApi,
+        Func<Game, string, string, string> expandVariables,
         ILogger logger,
         Game g,
         GameAction emulatorAction,
@@ -772,14 +782,14 @@ internal class ImportExportService
 
         // Expand variables using Playnite API
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = playniteApi.ExpandGameVariables(g, exePath, emulatorDir);
-        var expandedArgs = playniteApi.ExpandGameVariables(g, args, emulatorDir);
+        var expandedExe = expandVariables(g, exePath, emulatorDir);
+        var expandedArgs = expandVariables(g, args, emulatorDir);
 
         // Get working directory
         string? workDir = profile.WorkingDirectory;
         if (!string.IsNullOrWhiteSpace(workDir))
         {
-            workDir = playniteApi.ExpandGameVariables(g, workDir, emulatorDir);
+            workDir = expandVariables(g, workDir, emulatorDir);
         }
 
         logger.Info($"Resolved emulator for '{g.Name}': Exe={expandedExe}, Args={expandedArgs}");
@@ -810,11 +820,11 @@ internal class ImportExportService
         string? builtInConfigId,
         string name)
     {
-        return BuildBuiltInEmulatorResult(_library.PlayniteApi, Logger, _library.PlayniteApi.Emulation, g, emulatorAction, profile, emulatorInstallDir, builtInConfigId, name);
+        return BuildBuiltInEmulatorResult(_library.PlayniteApi.ExpandGameVariables, Logger, _library.PlayniteApi.Emulation, g, emulatorAction, profile, emulatorInstallDir, builtInConfigId, name);
     }
 
     internal static (string exePath, string? workDir, string name, GameAction? action) BuildBuiltInEmulatorResult(
-        IPlayniteAPI playniteApi,
+        Func<Game, string, string, string> expandVariables,
         ILogger logger,
         IEmulationAPI emulationApi,
         Game g,
@@ -887,8 +897,8 @@ internal class ImportExportService
 
         // Expand variables
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = playniteApi.ExpandGameVariables(g, exePath, emulatorDir);
-        var expandedArgs = playniteApi.ExpandGameVariables(g, args, emulatorDir);
+        var expandedExe = expandVariables(g, exePath, emulatorDir);
+        var expandedArgs = expandVariables(g, args, emulatorDir);
 
         // Working directory - use emulator install dir if not specified
         string? workDir = emulatorInstallDir;

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -246,11 +246,7 @@ internal class ImportExportService
                         return;
                     }
 
-                    if (res.WasSteamRunning)
-                    {
-                        Logger.Info("Restarting Steam after export...");
-                        SteamProcessHelper.TryLaunchSteam(_library.Settings.SteamRootPath);
-                    }
+                    RestartSteamIfNeeded(res.WasSteamRunning);
 
                     var msg = $"Steam shortcuts updated. Created: {res.Added}, Updated: {res.Updated}, Skipped: {res.Skipped}.";
                     _library.PlayniteApi.Dialogs.ShowMessage(msg, _library.Name);
@@ -282,11 +278,7 @@ internal class ImportExportService
             return;
         }
 
-        if (res.WasSteamRunning)
-        {
-            Logger.Info("Restarting Steam after export...");
-            SteamProcessHelper.TryLaunchSteam(_library.Settings.SteamRootPath);
-        }
+        RestartSteamIfNeeded(res.WasSteamRunning);
 
         var msg = $"Added: {res.Added}, Updated: {res.Updated}";
         if (res.Skipped > 0)
@@ -449,6 +441,17 @@ internal class ImportExportService
         return result == System.Windows.MessageBoxResult.Yes;
     }
 
+    private void RestartSteamIfNeeded(bool wasSteamRunning)
+    {
+        if (!wasSteamRunning)
+        {
+            return;
+        }
+
+        Logger.Info("Restarting Steam after export...");
+        SteamProcessHelper.TryLaunchSteam(_library.Settings.SteamRootPath);
+    }
+
     private ExportResult AddGamesToSteamCore(IEnumerable<Game> games)
     {
         var vdfPath = _pathResolver.ResolveShortcutsVdfPathForUser(_library.Settings.SelectedSteamUserId);
@@ -459,7 +462,6 @@ internal class ImportExportService
 
         if (!ConfirmSteamRestart())
         {
-            Logger.Info("User cancelled export.");
             return new ExportResult();
         }
 
@@ -496,7 +498,7 @@ internal class ImportExportService
                 skipped++;
                 var reason = GetSkipReason(g, result);
                 skippedGames.Add($"{g.Name}: {reason}");
-                Logger.Info($"Skipping '{g.Name}': {reason}");
+                Logger.Debug($"Skipping '{g.Name}': {reason}");
                 continue;
             }
 
@@ -505,7 +507,7 @@ internal class ImportExportService
             UpdateGameActions(g, appId, exePath, workDir, action);
         }
 
-        WriteShortcutsWithBackup(vdfPath!, shortcuts, context);
+        WriteShortcutsWithBackup(vdfPath!, shortcuts);
         return new ExportResult { Added = added, Updated = updated, Skipped = skipped, SkippedGames = skippedGames, WasSteamRunning = wasSteamRunning };
     }
 
@@ -1140,7 +1142,7 @@ internal class ImportExportService
             || val.StartsWith("steam://", StringComparison.OrdinalIgnoreCase);
     }
 
-    public void WriteShortcutsWithBackup(string vdfPath, List<SteamShortcut> shortcuts, ExportContext context)
+    public void WriteShortcutsWithBackup(string vdfPath, List<SteamShortcut> shortcuts)
     {
         try
         {

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -756,12 +756,12 @@ internal class ImportExportService
         string name)
     {
         // Get executable path
-        var exePath = profile.Executable ?? string.Empty;
+        var exePath = profile.Executable;
 
         // Resolve regex patterns to actual file paths
-        if (IsRegexPattern(exePath))
+        if (EmulatorPathUtils.IsRegexPattern(exePath))
         {
-            exePath = ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
+            exePath = EmulatorPathUtils.ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
             if (string.IsNullOrEmpty(exePath))
             {
                 return (string.Empty, null, name, null);
@@ -793,9 +793,10 @@ internal class ImportExportService
 
         // Expand variables using Playnite API
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = expandVariables(g, exePath, emulatorDir);
+        var resolvedExePath = exePath ?? string.Empty;
+        var expandedExe = expandVariables(g, resolvedExePath, emulatorDir);
         var expandedArgs = expandVariables(g, args, emulatorDir);
-        expandedArgs = QuoteArgumentsIfNeeded(expandedArgs);
+        expandedArgs = EmulatorPathUtils.QuoteArgumentsIfNeeded(expandedArgs);
 
         // Get working directory
         string? workDir = profile.WorkingDirectory;
@@ -870,12 +871,12 @@ internal class ImportExportService
         }
 
         // Get executable from the definition
-        var exePath = profileDef.StartupExecutable ?? string.Empty;
+        var exePath = profileDef.StartupExecutable;
 
         // Resolve regex patterns to actual file paths
-        if (IsRegexPattern(exePath))
+        if (EmulatorPathUtils.IsRegexPattern(exePath))
         {
-            exePath = ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
+            exePath = EmulatorPathUtils.ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
             if (string.IsNullOrEmpty(exePath))
             {
                 return (string.Empty, null, name, null);
@@ -920,9 +921,10 @@ internal class ImportExportService
 
         // Expand variables
         var emulatorDir = emulatorInstallDir ?? string.Empty;
-        var expandedExe = expandVariables(g, exePath, emulatorDir);
+        var resolvedExePath = exePath ?? string.Empty;
+        var expandedExe = expandVariables(g, resolvedExePath, emulatorDir);
         var expandedArgs = expandVariables(g, args, emulatorDir);
-        expandedArgs = QuoteArgumentsIfNeeded(expandedArgs);
+        expandedArgs = EmulatorPathUtils.QuoteArgumentsIfNeeded(expandedArgs);
 
         // Working directory - use emulator install dir if not specified
         string? workDir = emulatorInstallDir;
@@ -1148,87 +1150,6 @@ internal class ImportExportService
 
         ShortcutsFile.Write(vdfPath, shortcuts);
     }
-
-    #region Emulator Pattern Resolution
-
-    /// <summary>
-    /// Detects if a string looks like a regex pattern (rather than a literal file path).
-    /// </summary>
-    private static bool IsRegexPattern(string s)
-    {
-        if (string.IsNullOrEmpty(s)) return false;
-
-        // Check for regex-specific patterns:
-        // - ^ (start anchor)
-        // - $ (end anchor)
-        // - \\. (escaped dot, not just \\ which is in Windows paths)
-        // - .* (wildcard)
-        return s.StartsWith("^") || s.EndsWith("$") || s.Contains("\\.") || s.Contains(".*");
-    }
-
-    private static string QuoteArgumentsIfNeeded(string? args)
-    {
-        if (string.IsNullOrWhiteSpace(args)) return args ?? string.Empty;
-
-        var trimmed = args.Trim();
-        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
-        {
-            return trimmed;
-        }
-
-        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
-        {
-            return trimmed;
-        }
-
-        return "\"" + trimmed + "\"";
-    }
-
-    /// <summary>
-    /// Resolves a regex pattern to an actual executable file by matching against files in the emulator directory.
-    /// </summary>
-    private static string? ResolveExecutablePattern(string pattern, string? emulatorDir, ILogger logger, string gameName)
-    {
-        if (string.IsNullOrEmpty(emulatorDir) || !Directory.Exists(emulatorDir))
-        {
-            logger.Warn($"Cannot resolve emulator pattern for '{gameName}': Emulator directory not found ({emulatorDir})");
-            return null;
-        }
-
-        try
-        {
-            // Convert regex pattern to match against filenames
-            // Pattern like "^sameboy\\.exe$" should match "sameboy.exe"
-            var regexPattern = pattern;
-
-            // Ensure pattern has anchors for matching
-            if (!regexPattern.StartsWith("^")) regexPattern = "^" + regexPattern;
-            if (!regexPattern.EndsWith("$")) regexPattern = regexPattern + "$";
-
-            var regex = new System.Text.RegularExpressions.Regex(regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
-            // Scan for matching executables in the emulator directory
-            foreach (var file in Directory.EnumerateFiles(emulatorDir, "*.exe", SearchOption.TopDirectoryOnly))
-            {
-                var fileName = Path.GetFileName(file);
-                if (regex.IsMatch(fileName))
-                {
-                    logger.Info($"Resolved emulator pattern '{pattern}' to '{file}' for '{gameName}'");
-                    return file;
-                }
-            }
-
-            logger.Warn($"Cannot export '{gameName}': No executable matching pattern '{pattern}' found in {emulatorDir}");
-        }
-        catch (Exception ex)
-        {
-            logger.Warn(ex, $"Failed to resolve emulator pattern '{pattern}' for '{gameName}'");
-        }
-
-        return null;
-    }
-
-    #endregion
 
     #region Nested Classes
 

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -1070,7 +1070,8 @@ internal class ImportExportService
         }
         else if (action.Type == GameActionType.File)
         {
-            sc.LaunchOptions = _pathResolver.ExpandPathVariables(g, action.Arguments) ?? string.Empty;
+            var expandedArgs = _pathResolver.ExpandPathVariables(g, action.Arguments) ?? string.Empty;
+            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(expandedArgs);
         }
 
         try

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -1119,7 +1119,10 @@ internal class ImportExportService
     {
         try
         {
-            _library.EnsureFileActionForExternalGame(g, exePath, workDir, action.Type == GameActionType.File ? _pathResolver.ExpandPathVariables(g, action.Arguments) : null);
+            var fileArgs = action.Type == GameActionType.File
+                ? EmulatorPathUtils.QuoteArgumentsIfNeeded(_pathResolver.ExpandPathVariables(g, action.Arguments))
+                : null;
+            _library.EnsureFileActionForExternalGame(g, exePath, workDir, fileArgs);
             if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId); }
         }
         catch (Exception ex)

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -183,16 +183,6 @@ public class ShortcutsLibrary : LibraryPlugin
         return Instance?.PlayniteApi;
     }
 
-    private void CreateManagedBackup(string sourceFilePath, string userId)
-    {
-        _backupManager.CreateManagedBackup(sourceFilePath, userId);
-    }
-
-    private static string? TryGetSteamUserFromPath(string path)
-    {
-        return BackupManager.TryGetSteamUserFromPath(path);
-    }
-
     public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)
     {
         yield return new MainMenuItem

--- a/src/SteamShortcutsImporter/SteamPathResolver.cs
+++ b/src/SteamShortcutsImporter/SteamPathResolver.cs
@@ -176,8 +176,6 @@ internal class SteamPathResolver
         }
     }
 
-    #region Executable Discovery
-
     /// <summary>
     /// Patterns for executables that are typically not the main game executable.
     /// </summary>
@@ -503,5 +501,4 @@ internal class SteamPathResolver
         return result;
     }
 
-    #endregion
 }

--- a/src/SteamShortcutsImporter/SteamProcessHelper.cs
+++ b/src/SteamShortcutsImporter/SteamProcessHelper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 
 namespace SteamShortcutsImporter;
 
@@ -10,6 +9,8 @@ namespace SteamShortcutsImporter;
 /// </summary>
 internal static class SteamProcessHelper
 {
+    private static readonly Playnite.SDK.ILogger Logger = Playnite.SDK.LogManager.GetLogger();
+
     /// <summary>
     /// Checks if the Steam client is currently running.
     /// </summary>
@@ -72,17 +73,14 @@ if (processes.Any())
     {
         try
         {
-            var logger = Playnite.SDK.LogManager.GetLogger();
-            
             // Check if Steam is running first
             if (!IsSteamRunning())
             {
-                logger.Info("Steam is not running, nothing to close.");
                 return false;
             }
 
             // Use Windows taskkill command to force-close Steam
-            logger.Info("Closing Steam using taskkill /F /IM Steam.exe");
+            Logger.Info("Closing Steam using taskkill /F /IM Steam.exe");
             
             var processStartInfo = new ProcessStartInfo
             {
@@ -98,7 +96,7 @@ if (processes.Any())
             {
                 if (process == null)
                 {
-                    logger.Warn("Failed to start taskkill process");
+                    Logger.Warn("Failed to start taskkill process");
                     return false;
                 }
 
@@ -109,15 +107,15 @@ if (processes.Any())
                 
                 if (!string.IsNullOrWhiteSpace(output))
                 {
-                    logger.Info($"taskkill output: {output}");
+                    Logger.Debug($"taskkill output: {output}");
                 }
                 
                 if (!string.IsNullOrWhiteSpace(error))
                 {
-                    logger.Warn($"taskkill error: {error}");
+                    Logger.Warn($"taskkill error: {error}");
                 }
                 
-                logger.Info($"taskkill exit code: {process.ExitCode}");
+                Logger.Info($"taskkill exit code: {process.ExitCode}");
             }
             
             // Give Windows a moment to clean up the process
@@ -126,14 +124,12 @@ if (processes.Any())
             // Verify Steam closed
             if (IsSteamRunning())
             {
-                logger.Warn("Steam still running after taskkill");
+                Logger.Warn("Steam still running after taskkill");
                 return false;
             }
-            else
-            {
-                logger.Info("Steam closed successfully");
-                return true;
-            }
+
+            Logger.Info("Steam closed successfully");
+            return true;
         }
         catch (Exception ex)
         {

--- a/src/SteamShortcutsImporter/SteamShortcutsImporter.csproj
+++ b/src/SteamShortcutsImporter/SteamShortcutsImporter.csproj
@@ -25,4 +25,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="System.Xaml" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ShortcutsTests" />
+  </ItemGroup>
 </Project>

--- a/src/SteamShortcutsImporter/SteamUsersReader.cs
+++ b/src/SteamShortcutsImporter/SteamUsersReader.cs
@@ -51,7 +51,7 @@ internal static class SteamUsersReader
             // Read with UTF-8 BOM detection
             var content = File.ReadAllText(loginusersPath, Encoding.UTF8);
             ParseLoginUsers(content, result);
-            Logger.Info($"Read {result.Count} user(s) from loginusers.vdf");
+            Logger.Debug($"Read {result.Count} user(s) from loginusers.vdf");
         }
         catch (Exception ex)
         {

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace SteamShortcutsImporter;
@@ -144,7 +145,7 @@ internal class WriteBackHandler : IDisposable
     private void UpdateShortcutFromGame(Game game, SteamShortcut sc)
     {
         sc.AppName = game.Name;
-        // Prefer direct file action to refresh exe/args/dir
+        
         var act = game.GameActions?.FirstOrDefault(a => a.Type == GameActionType.File)
                   ?? game.GameActions?.FirstOrDefault(a => a.IsPlayAction)
                   ?? game.GameActions?.FirstOrDefault();
@@ -167,7 +168,7 @@ internal class WriteBackHandler : IDisposable
             sc.AppId = Utils.GenerateShortcutAppId(sc.Exe, sc.AppName);
         }
 
-        // Normalize play action to Steam URL when enabled
+        
         EnsureSteamPlayAction(game, sc);
     }
 
@@ -204,9 +205,15 @@ internal class WriteBackHandler : IDisposable
                 game.IsInstalled = true;
                 var newActions = new List<GameAction>();
                 
-                // If steam launch is enabled, add steam URL as primary and file action as secondary
-                if (true) // Assuming steam launch is enabled - this should be configurable
+                if (true)
                 {
+                    var directExe = sc.Exe?.Trim('"');
+                    if (IsRegexPattern(directExe))
+                    {
+                        directExe = ResolveExecutablePattern(directExe!, sc.StartDir ?? game.InstallDirectory, game.Name);
+                    }
+
+                    var directArgs = QuoteArgumentsIfNeeded(sc.LaunchOptions);
                     newActions.Add(new GameAction
                     {
                         Name = Constants.PlaySteamActionName,
@@ -218,8 +225,8 @@ internal class WriteBackHandler : IDisposable
                     {
                         Name = Constants.PlayDirectActionName,
                         Type = GameActionType.File,
-                        Path = sc.Exe?.Trim('"'),
-                        Arguments = sc.LaunchOptions,
+                        Path = directExe,
+                        Arguments = directArgs,
                         WorkingDir = sc.StartDir,
                         IsPlayAction = false
                     });
@@ -233,5 +240,61 @@ internal class WriteBackHandler : IDisposable
         {
             _logger.Warn(ex, $"Failed to ensure Steam play action for game '{game.Name}'");
         }
+    }
+
+    private static bool IsRegexPattern(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return false;
+        return s.StartsWith("^") || s.EndsWith("$") || s.Contains("\\.") || s.Contains(".*");
+    }
+
+    private string? ResolveExecutablePattern(string pattern, string? emulatorDir, string gameName)
+    {
+        if (string.IsNullOrEmpty(emulatorDir) || !Directory.Exists(emulatorDir))
+        {
+            return null;
+        }
+
+        try
+        {
+            var regexPattern = pattern;
+            if (!regexPattern.StartsWith("^")) regexPattern = "^" + regexPattern;
+            if (!regexPattern.EndsWith("$")) regexPattern = regexPattern + "$";
+
+            var regex = new Regex(regexPattern, RegexOptions.IgnoreCase);
+            foreach (var file in Directory.EnumerateFiles(emulatorDir, "*.exe", SearchOption.TopDirectoryOnly))
+            {
+                var fileName = Path.GetFileName(file);
+                if (regex.IsMatch(fileName))
+                {
+                    _logger.Info($"Resolved emulator pattern '{pattern}' to '{file}' for '{gameName}'");
+                    return file;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn(ex, $"Failed to resolve emulator pattern '{pattern}' for '{gameName}'");
+        }
+
+        return null;
+    }
+
+    private static string QuoteArgumentsIfNeeded(string? args)
+    {
+        if (string.IsNullOrWhiteSpace(args)) return args ?? string.Empty;
+
+        var trimmed = args.Trim();
+        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
+        {
+            return trimmed;
+        }
+
+        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
+        {
+            return trimmed;
+        }
+
+        return "\"" + trimmed + "\"";
     }
 }

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -100,8 +100,9 @@ internal class WriteBackHandler : IDisposable
             }
 
             var shortcuts = ShortcutsFile.Read(vdfPath!).ToList();
-            var byStable = shortcuts.ToDictionary(s => s.StableId, s => s, StringComparer.OrdinalIgnoreCase);
-            var byApp = shortcuts.ToDictionary(s => s.AppId.ToString(), s => s, StringComparer.OrdinalIgnoreCase);
+            // Use GroupBy to handle duplicates safely (keep first occurrence)
+            var byStable = shortcuts.GroupBy(s => s.StableId, StringComparer.OrdinalIgnoreCase).ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+            var byApp = shortcuts.GroupBy(s => s.AppId.ToString(), StringComparer.OrdinalIgnoreCase).ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
             bool changed = false;
 
             // Check all games from this library and sync any that changed

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -132,7 +132,7 @@ internal class WriteBackHandler : IDisposable
             if (changed)
             {
                 _logger.Info($"Writing debounced updates to shortcuts.vdf for {ourGames.Count} game(s).");
-                _importExportService.WriteShortcutsWithBackup(vdfPath!, shortcuts, new ExportContext());
+                _importExportService.WriteShortcutsWithBackup(vdfPath!, shortcuts);
             }
         }
         catch (Exception ex)

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace SteamShortcutsImporter;
@@ -205,32 +204,29 @@ internal class WriteBackHandler : IDisposable
                 game.IsInstalled = true;
                 var newActions = new List<GameAction>();
                 
-                if (true)
+                var directExe = sc.Exe?.Trim('"');
+                if (EmulatorPathUtils.IsRegexPattern(directExe))
                 {
-                    var directExe = sc.Exe?.Trim('"');
-                    if (IsRegexPattern(directExe))
-                    {
-                        directExe = ResolveExecutablePattern(directExe!, sc.StartDir ?? game.InstallDirectory, game.Name);
-                    }
-
-                    var directArgs = QuoteArgumentsIfNeeded(sc.LaunchOptions);
-                    newActions.Add(new GameAction
-                    {
-                        Name = Constants.PlaySteamActionName,
-                        Type = GameActionType.URL,
-                        Path = expectedUrl,
-                        IsPlayAction = true
-                    });
-                    newActions.Add(new GameAction
-                    {
-                        Name = Constants.PlayDirectActionName,
-                        Type = GameActionType.File,
-                        Path = directExe,
-                        Arguments = directArgs,
-                        WorkingDir = sc.StartDir,
-                        IsPlayAction = false
-                    });
+                    directExe = EmulatorPathUtils.ResolveExecutablePattern(directExe!, sc.StartDir ?? game.InstallDirectory, _logger, game.Name);
                 }
+
+                var directArgs = EmulatorPathUtils.QuoteArgumentsIfNeeded(sc.LaunchOptions);
+                newActions.Add(new GameAction
+                {
+                    Name = Constants.PlaySteamActionName,
+                    Type = GameActionType.URL,
+                    Path = expectedUrl,
+                    IsPlayAction = true
+                });
+                newActions.Add(new GameAction
+                {
+                    Name = Constants.PlayDirectActionName,
+                    Type = GameActionType.File,
+                    Path = directExe,
+                    Arguments = directArgs,
+                    WorkingDir = sc.StartDir,
+                    IsPlayAction = false
+                });
                 
                 game.GameActions = new System.Collections.ObjectModel.ObservableCollection<GameAction>(newActions);
                 _playniteApi?.Database?.Games?.Update(game);
@@ -242,59 +238,4 @@ internal class WriteBackHandler : IDisposable
         }
     }
 
-    private static bool IsRegexPattern(string? s)
-    {
-        if (string.IsNullOrEmpty(s)) return false;
-        return s.StartsWith("^") || s.EndsWith("$") || s.Contains("\\.") || s.Contains(".*");
-    }
-
-    private string? ResolveExecutablePattern(string pattern, string? emulatorDir, string gameName)
-    {
-        if (string.IsNullOrEmpty(emulatorDir) || !Directory.Exists(emulatorDir))
-        {
-            return null;
-        }
-
-        try
-        {
-            var regexPattern = pattern;
-            if (!regexPattern.StartsWith("^")) regexPattern = "^" + regexPattern;
-            if (!regexPattern.EndsWith("$")) regexPattern = regexPattern + "$";
-
-            var regex = new Regex(regexPattern, RegexOptions.IgnoreCase);
-            foreach (var file in Directory.EnumerateFiles(emulatorDir, "*.exe", SearchOption.TopDirectoryOnly))
-            {
-                var fileName = Path.GetFileName(file);
-                if (regex.IsMatch(fileName))
-                {
-                    _logger.Info($"Resolved emulator pattern '{pattern}' to '{file}' for '{gameName}'");
-                    return file;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.Warn(ex, $"Failed to resolve emulator pattern '{pattern}' for '{gameName}'");
-        }
-
-        return null;
-    }
-
-    private static string QuoteArgumentsIfNeeded(string? args)
-    {
-        if (string.IsNullOrWhiteSpace(args)) return args ?? string.Empty;
-
-        var trimmed = args.Trim();
-        if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) || !trimmed.Contains(" "))
-        {
-            return trimmed;
-        }
-
-        if (trimmed.Contains(" --") || trimmed.Contains(" -"))
-        {
-            return trimmed;
-        }
-
-        return "\"" + trimmed + "\"";
-    }
 }

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -158,7 +158,7 @@ internal class WriteBackHandler : IDisposable
                 try { dir = Path.GetDirectoryName(exe) ?? sc.StartDir; } catch (Exception ex) { _logger.Warn(ex, "Failed to get directory name."); dir = sc.StartDir; }
             }
             sc.Exe = exe;
-            sc.LaunchOptions = args;
+            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(args);
             sc.StartDir = dir ?? sc.StartDir;
         }
 

--- a/tests/ShortcutsTests/EmulatorSupportTests.cs
+++ b/tests/ShortcutsTests/EmulatorSupportTests.cs
@@ -13,17 +13,15 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildEmulatorActionResult_MissingEmulator_ReturnsNullAction()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var game = CreateGame("Test Game");
         var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
 
-        var database = Substitute.For<IGameDatabaseAPI>();
-        var emulators = CreateEmulatorCollection();
-        database.Emulators.Returns(emulators);
-        api.Database.Returns(database);
+        var emulators = new List<Emulator>();
+        var emulation = Substitute.For<IEmulationAPI>();
 
-        var result = ImportExportService.BuildEmulatorActionResult(api, logger, game, action);
+        var result = ImportExportService.BuildEmulatorActionResult(emulators, emulation, expand, logger, game, action);
 
         Assert.Null(result.action);
         Assert.Equal("Test Game", result.name);
@@ -32,7 +30,7 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildCustomEmulatorResult_OverrideDefaultArgs_UsesOnlyActionArgs()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var game = CreateGame("Test Game");
         var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
@@ -46,7 +44,7 @@ public class EmulatorSupportTests
             WorkingDirectory = @"C:\Emu"
         };
 
-        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+        var result = ImportExportService.BuildCustomEmulatorResult(expand, logger, game, action, profile, @"C:\Emu", "Test Game");
 
         Assert.NotNull(result.action);
         Assert.Equal("--fullscreen --volume=50", result.action.Arguments);
@@ -55,7 +53,7 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildCustomEmulatorResult_WithoutOverride_CombinesArgs()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var game = CreateGame("Test Game");
         var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
@@ -68,7 +66,7 @@ public class EmulatorSupportTests
             WorkingDirectory = @"C:\Emu"
         };
 
-        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+        var result = ImportExportService.BuildCustomEmulatorResult(expand, logger, game, action, profile, @"C:\Emu", "Test Game");
 
         Assert.NotNull(result.action);
         Assert.Equal("\"{ImagePath}\" --fullscreen", result.action.Arguments);
@@ -77,7 +75,7 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildCustomEmulatorResult_EmptyExecutable_ReturnsNullAction()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var game = CreateGame("Test Game");
         var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
@@ -88,7 +86,7 @@ public class EmulatorSupportTests
             Arguments = "-f"
         };
 
-        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+        var result = ImportExportService.BuildCustomEmulatorResult(expand, logger, game, action, profile, @"C:\Emu", "Test Game");
 
         Assert.Null(result.action);
     }
@@ -96,7 +94,7 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildBuiltInEmulatorResult_ProfileOverride_DefaultArgs_UsesCustomArgsOnly()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var emulation = Substitute.For<IEmulationAPI>();
         var game = CreateGame("Test Game");
@@ -127,7 +125,7 @@ public class EmulatorSupportTests
         emulation.GetEmulator("retroarch").Returns(definition);
 
         var result = ImportExportService.BuildBuiltInEmulatorResult(
-            api,
+            expand,
             logger,
             emulation,
             game,
@@ -144,7 +142,7 @@ public class EmulatorSupportTests
     [Fact]
     public void BuildBuiltInEmulatorResult_ActionOverride_DefaultArgs_UsesOnlyActionArgs()
     {
-        var api = CreatePlayniteApi();
+        var expand = CreateExpand();
         var logger = Substitute.For<ILogger>();
         var emulation = Substitute.For<IEmulationAPI>();
         var game = CreateGame("Test Game");
@@ -176,7 +174,7 @@ public class EmulatorSupportTests
         emulation.GetEmulator("retroarch").Returns(definition);
 
         var result = ImportExportService.BuildBuiltInEmulatorResult(
-            api,
+            expand,
             logger,
             emulation,
             game,
@@ -211,29 +209,8 @@ public class EmulatorSupportTests
         };
     }
 
-    private static IPlayniteAPI CreatePlayniteApi()
+    private static Func<Game, string, string, string> CreateExpand()
     {
-        var api = Substitute.For<IPlayniteAPI>();
-        api.Database.Returns(Substitute.For<IGameDatabaseAPI>());
-        api.Emulation.Returns(Substitute.For<IEmulationAPI>());
-        api.ExpandGameVariables(Arg.Any<Game>(), Arg.Any<string>(), Arg.Any<string>())
-            .Returns(info => info.ArgAt<string>(1));
-        return api;
-    }
-
-    private static IItemCollection<Emulator> CreateEmulatorCollection(params Emulator[] emulators)
-    {
-        var collection = Substitute.For<IItemCollection<Emulator>>();
-        var list = new List<Emulator>(emulators);
-
-        collection.GetEnumerator().Returns(list.GetEnumerator());
-        ((System.Collections.IEnumerable)collection).GetEnumerator().Returns(list.GetEnumerator());
-        collection.ContainsItem(Arg.Any<Guid>()).Returns(callInfo =>
-        {
-            var id = callInfo.Arg<Guid>();
-            return list.Exists(emulator => emulator.Id == id);
-        });
-
-        return collection;
+        return (_, input, __) => input;
     }
 }

--- a/tests/ShortcutsTests/EmulatorSupportTests.cs
+++ b/tests/ShortcutsTests/EmulatorSupportTests.cs
@@ -73,6 +73,50 @@ public class EmulatorSupportTests
     }
 
     [Fact]
+    public void BuildCustomEmulatorResult_QuotesArgsWithSpaces()
+    {
+        var expand = CreateExpand();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.AdditionalArguments = "C:\\Games\\ROMs\\Game Boy\\Pokemon Red.gb";
+
+        var profile = new CustomEmulatorProfile
+        {
+            Executable = @"C:\\Emu\\emu.exe",
+            Arguments = string.Empty,
+            WorkingDirectory = @"C:\\Emu"
+        };
+
+        var result = ImportExportService.BuildCustomEmulatorResult(expand, logger, game, action, profile, @"C:\\Emu", "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("\"C:\\Games\\ROMs\\Game Boy\\Pokemon Red.gb\"", result.action.Arguments);
+    }
+
+    [Fact]
+    public void BuildCustomEmulatorResult_DoesNotQuoteFlagArgs()
+    {
+        var expand = CreateExpand();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.AdditionalArguments = "--fullscreen --volume=50";
+
+        var profile = new CustomEmulatorProfile
+        {
+            Executable = @"C:\\Emu\\emu.exe",
+            Arguments = string.Empty,
+            WorkingDirectory = @"C:\\Emu"
+        };
+
+        var result = ImportExportService.BuildCustomEmulatorResult(expand, logger, game, action, profile, @"C:\\Emu", "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("--fullscreen --volume=50", result.action.Arguments);
+    }
+
+    [Fact]
     public void BuildCustomEmulatorResult_EmptyExecutable_ReturnsNullAction()
     {
         var expand = CreateExpand();
@@ -214,3 +258,6 @@ public class EmulatorSupportTests
         return (_, input, __) => input;
     }
 }
+
+// Note: Tests for regex pattern resolution (IsRegexPattern and ResolveExecutablePattern)
+// are in PatternResolutionTests.cs to allow file system operations on .NET 6.0

--- a/tests/ShortcutsTests/EmulatorSupportTests.cs
+++ b/tests/ShortcutsTests/EmulatorSupportTests.cs
@@ -1,0 +1,239 @@
+using NSubstitute;
+using Playnite.SDK;
+using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace SteamShortcutsImporter.Tests;
+
+public class EmulatorSupportTests
+{
+    [Fact]
+    public void BuildEmulatorActionResult_MissingEmulator_ReturnsNullAction()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+
+        var database = Substitute.For<IGameDatabaseAPI>();
+        var emulators = CreateEmulatorCollection();
+        database.Emulators.Returns(emulators);
+        api.Database.Returns(database);
+
+        var result = ImportExportService.BuildEmulatorActionResult(api, logger, game, action);
+
+        Assert.Null(result.action);
+        Assert.Equal("Test Game", result.name);
+    }
+
+    [Fact]
+    public void BuildCustomEmulatorResult_OverrideDefaultArgs_UsesOnlyActionArgs()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.OverrideDefaultArgs = true;
+        action.AdditionalArguments = "--fullscreen --volume=50";
+
+        var profile = new CustomEmulatorProfile
+        {
+            Executable = @"C:\Emu\emu.exe",
+            Arguments = "--default-arg",
+            WorkingDirectory = @"C:\Emu"
+        };
+
+        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("--fullscreen --volume=50", result.action.Arguments);
+    }
+
+    [Fact]
+    public void BuildCustomEmulatorResult_WithoutOverride_CombinesArgs()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.AdditionalArguments = "--fullscreen";
+
+        var profile = new CustomEmulatorProfile
+        {
+            Executable = @"C:\Emu\emu.exe",
+            Arguments = "\"{ImagePath}\"",
+            WorkingDirectory = @"C:\Emu"
+        };
+
+        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("\"{ImagePath}\" --fullscreen", result.action.Arguments);
+    }
+
+    [Fact]
+    public void BuildCustomEmulatorResult_EmptyExecutable_ReturnsNullAction()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+
+        var profile = new CustomEmulatorProfile
+        {
+            Executable = "",
+            Arguments = "-f"
+        };
+
+        var result = ImportExportService.BuildCustomEmulatorResult(api, logger, game, action, profile, @"C:\Emu", "Test Game");
+
+        Assert.Null(result.action);
+    }
+
+    [Fact]
+    public void BuildBuiltInEmulatorResult_ProfileOverride_DefaultArgs_UsesCustomArgsOnly()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var emulation = Substitute.For<IEmulationAPI>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.AdditionalArguments = "--user-arg";
+
+        var profile = new BuiltInEmulatorProfile
+        {
+            BuiltInProfileName = "Balanced",
+            CustomArguments = "--custom-arg",
+            OverrideDefaultArgs = true
+        };
+
+        var definition = new EmulatorDefinition
+        {
+            Id = "retroarch",
+            Profiles = new List<EmulatorDefinitionProfile>
+            {
+                new EmulatorDefinitionProfile
+                {
+                    Name = "Balanced",
+                    StartupExecutable = @"retroarch.exe",
+                    StartupArguments = @"-L ""{ImagePath}"""
+                }
+            }
+        };
+
+        emulation.GetEmulator("retroarch").Returns(definition);
+
+        var result = ImportExportService.BuildBuiltInEmulatorResult(
+            api,
+            logger,
+            emulation,
+            game,
+            action,
+            profile,
+            @"C:\RetroArch",
+            "retroarch",
+            "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("--custom-arg", result.action.Arguments);
+    }
+
+    [Fact]
+    public void BuildBuiltInEmulatorResult_ActionOverride_DefaultArgs_UsesOnlyActionArgs()
+    {
+        var api = CreatePlayniteApi();
+        var logger = Substitute.For<ILogger>();
+        var emulation = Substitute.For<IEmulationAPI>();
+        var game = CreateGame("Test Game");
+        var action = CreateEmulatorAction(Guid.NewGuid(), "profile-1");
+        action.OverrideDefaultArgs = true;
+        action.AdditionalArguments = "--user-arg";
+
+        var profile = new BuiltInEmulatorProfile
+        {
+            BuiltInProfileName = "Balanced",
+            CustomArguments = "--custom-arg",
+            OverrideDefaultArgs = false
+        };
+
+        var definition = new EmulatorDefinition
+        {
+            Id = "retroarch",
+            Profiles = new List<EmulatorDefinitionProfile>
+            {
+                new EmulatorDefinitionProfile
+                {
+                    Name = "Balanced",
+                    StartupExecutable = @"retroarch.exe",
+                    StartupArguments = @"-L ""{ImagePath}"""
+                }
+            }
+        };
+
+        emulation.GetEmulator("retroarch").Returns(definition);
+
+        var result = ImportExportService.BuildBuiltInEmulatorResult(
+            api,
+            logger,
+            emulation,
+            game,
+            action,
+            profile,
+            @"C:\RetroArch",
+            "retroarch",
+            "Test Game");
+
+        Assert.NotNull(result.action);
+        Assert.Equal("--user-arg", result.action.Arguments);
+    }
+
+    private static Game CreateGame(string name)
+    {
+        return new Game
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            GameActions = new ObservableCollection<GameAction>()
+        };
+    }
+
+    private static GameAction CreateEmulatorAction(Guid emulatorId, string profileId)
+    {
+        return new GameAction
+        {
+            Type = GameActionType.Emulator,
+            EmulatorId = emulatorId,
+            EmulatorProfileId = profileId,
+            IsPlayAction = true
+        };
+    }
+
+    private static IPlayniteAPI CreatePlayniteApi()
+    {
+        var api = Substitute.For<IPlayniteAPI>();
+        api.Database.Returns(Substitute.For<IGameDatabaseAPI>());
+        api.Emulation.Returns(Substitute.For<IEmulationAPI>());
+        api.ExpandGameVariables(Arg.Any<Game>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(info => info.ArgAt<string>(1));
+        return api;
+    }
+
+    private static IItemCollection<Emulator> CreateEmulatorCollection(params Emulator[] emulators)
+    {
+        var collection = Substitute.For<IItemCollection<Emulator>>();
+        var list = new List<Emulator>(emulators);
+
+        collection.GetEnumerator().Returns(list.GetEnumerator());
+        ((System.Collections.IEnumerable)collection).GetEnumerator().Returns(list.GetEnumerator());
+        collection.ContainsItem(Arg.Any<Guid>()).Returns(callInfo =>
+        {
+            var id = callInfo.Arg<Guid>();
+            return list.Exists(emulator => emulator.Id == id);
+        });
+
+        return collection;
+    }
+}

--- a/tests/ShortcutsTests/ShortcutsTests.csproj
+++ b/tests/ShortcutsTests/ShortcutsTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds support for games with `Emulator` play action types when exporting to Steam shortcuts
- Resolves emulator profiles to extract executable path, arguments, and working directory
- Supports both `CustomEmulatorProfile` and `BuiltInEmulatorProfile` types
- Properly handles `OverrideDefaultArgs` and `AdditionalArguments` from game actions
- Expands ROM path variables like `{ImagePath}` using Playnite's `ExpandGameVariables` API

## Changes

- Added `BuildEmulatorActionResult()` to resolve emulator from database and dispatch to profile handlers
- Added `BuildCustomEmulatorResult()` for custom emulator profiles
- Added `BuildBuiltInEmulatorResult()` for built-in emulator profiles
- Updated fallback chain in `GetGameActionDetailsWithFallback()` to check emulator actions
- Added emulator unit tests with NSubstitute-based Playnite API stubs

## Testing

- ✅ `dotnet build src/SteamShortcutsImporter/SteamShortcutsImporter.csproj`
- ✅ `dotnet test tests/ShortcutsTests/ShortcutsTests.csproj` (139 tests)

Closes #15