### PR TITLE
fix(emulator): remove regex handling for CustomEmulatorProfile

### DIFF
--- a/src/SteamShortcutsImporter/EmulatorPathUtils.cs
+++ b/src/SteamShortcutsImporter/EmulatorPathUtils.cs
@@ -16,17 +16,19 @@ internal static class EmulatorPathUtils
 
         var value = s ?? string.Empty;
 
+        // Only detect unambiguous regex patterns
+        // Explicit anchors indicate regex intent
         if (value.StartsWith("^") || value.EndsWith("$"))
         {
             return true;
         }
 
-        if (value.Contains("\\d") || value.Contains("\\w") || value.Contains("\\s") || value.Contains("\\."))
-        {
-            return true;
-        }
-
-        if (value.Contains(".*") || value.Contains(".+") || value.Contains(".?") || value.Contains("[") || value.Contains("]")
+        // Character classes, groups, and alternation that don't appear in typical paths
+        // Note: We don't check for \d, \w, \s, \. or .* patterns since these appear in Windows paths
+        // e.g., C:\Games\DuckStation\duckstation.exe contains \d
+        // e.g., C:\Games\My.Program\app.exe contains \. 
+        // e.g., C:\Games\Game.v1.0\app.exe could match .+ pattern
+        if (value.Contains("[") || value.Contains("]")
             || value.Contains("(") || value.Contains(")") || value.Contains("{") || value.Contains("}") || value.Contains("|"))
         {
             return true;

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -757,25 +757,14 @@ internal class ImportExportService
         string? emulatorInstallDir,
         string name)
     {
-        // Get executable path
+        // Get executable path (no regex resolution - Playnite uses CustomEmulatorProfile.Executable directly)
         var exePath = profile.Executable;
-
-        // Resolve regex patterns to actual file paths
-        if (EmulatorPathUtils.IsRegexPattern(exePath))
-        {
-            exePath = EmulatorPathUtils.ResolveExecutablePattern(exePath, emulatorInstallDir, logger, g.Name);
-            if (string.IsNullOrEmpty(exePath))
-            {
-                return (string.Empty, null, name, null);
-            }
-        }
 
         if (string.IsNullOrWhiteSpace(exePath))
         {
             logger.Warn($"Cannot export '{g.Name}': Emulator profile has no executable set");
             return (string.Empty, null, name, null);
         }
-
         // Build arguments (considering OverrideDefaultArgs and AdditionalArguments)
         string args;
         if (emulatorAction.OverrideDefaultArgs)
@@ -1121,10 +1110,17 @@ internal class ImportExportService
     {
         try
         {
-            var fileArgs = action.Type == GameActionType.File
-                ? EmulatorPathUtils.QuoteArgumentsIfNeeded(_pathResolver.ExpandPathVariables(g, action.Arguments))
-                : null;
-            _library.EnsureFileActionForExternalGame(g, exePath, workDir, fileArgs);
+            // Don't add "Play (Direct)" File action if the game already has an Emulator action.
+            // Emulator games are launched via the emulator, not directly.
+            var hasEmulatorAction = g.GameActions?.Any(a => a.Type == GameActionType.Emulator) == true;
+            if (!hasEmulatorAction)
+            {
+                var fileArgs = action.Type == GameActionType.File
+                    ? EmulatorPathUtils.QuoteArgumentsIfNeeded(_pathResolver.ExpandPathVariables(g, action.Arguments))
+                    : null;
+                _library.EnsureFileActionForExternalGame(g, exePath, workDir, fileArgs);
+            }
+            
             if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId); }
         }
         catch (Exception ex)

--- a/tests/ShortcutsTests/EmulatorPathUtilsTests.cs
+++ b/tests/ShortcutsTests/EmulatorPathUtilsTests.cs
@@ -127,19 +127,19 @@ public class EmulatorPathUtilsTests
     }
 
     [Fact]
-    public void IsRegexPattern_ContainsDigitClass_ReturnsTrue()
+    public void IsRegexPattern_ContainsDigitClass_ReturnsFalse()
     {
+        // \d in paths is common (e.g., C:\Games\DuckStation\...)
         var result = EmulatorPathUtils.IsRegexPattern("emu\\d+.exe");
-        Assert.True(result);
+        Assert.False(result);
     }
-
     [Fact]
-    public void IsRegexPattern_ContainsWordClass_ReturnsTrue()
+    public void IsRegexPattern_ContainsWordClass_ReturnsFalse()
     {
+        // \w in paths is common (e.g., C:\Games\MyWork\...)
         var result = EmulatorPathUtils.IsRegexPattern("\\w+.exe");
-        Assert.True(result);
+        Assert.False(result);
     }
-
     [Fact]
     public void IsRegexPattern_PlainFilename_ReturnsFalse()
     {
@@ -164,9 +164,34 @@ public class EmulatorPathUtilsTests
     }
 
     [Fact]
-    public void IsRegexPattern_WildcardDotStar_ReturnsTrue()
+    public void IsRegexPattern_WildcardDotStar_ReturnsFalse()
     {
+        // .* can appear in version strings (e.g., game.v1.0.exe)
         var result = EmulatorPathUtils.IsRegexPattern(".*.exe");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsRegexPattern_WindowsPathWithBackslashD_ReturnsFalse()
+    {
+        // Real Windows path containing \duckstation\ should NOT be treated as regex
+        var result = EmulatorPathUtils.IsRegexPattern("C:\\Games\\DuckStation\\duckstation.exe");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsRegexPattern_ContainsCharacterClass_ReturnsTrue()
+    {
+        // [...] is unambiguous regex
+        var result = EmulatorPathUtils.IsRegexPattern("emu[0-9].exe");
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRegexPattern_ContainsGroup_ReturnsTrue()
+    {
+        // (...) is unambiguous regex
+        var result = EmulatorPathUtils.IsRegexPattern("(retro|duck).exe");
         Assert.True(result);
     }
 


### PR DESCRIPTION
## Summary

Fixes #19 - Emulator executable paths containing regex-like sequences (e.g., `C:\Games\DuckStation\`) were incorrectly being treated as regex patterns, and "Play (Direct)" was being added to emulator games unnecessarily.

## Root Causes

### 1. Incorrect regex handling for CustomEmulatorProfile
The plugin incorrectly added regex pattern support for `CustomEmulatorProfile.Executable`, but **Playnite itself never uses regex for custom profiles** - only for `BuiltInEmulatorProfile`.

Playnite behavior (verified in source):
- **BuiltInEmulatorProfile**: Uses regex via [`Emulation.GetExecutable()`](https://github.com/JosefNemec/Playnite/blob/master/source/Playnite/Emulators/Emulation.cs#L222) to match `profileDef.StartupExecutable` patterns like `^duckstation-qt-x64-ReleaseLTCG\.exe$`
- **CustomEmulatorProfile**: Uses `Executable` path directly, **no regex**

### 2. "Play (Direct)" added for emulator games
When exporting to Steam, the plugin was adding a "Play (Direct)" File action to ALL games, including those with Emulator actions. This is incorrect - users who configure emulator games don't need a direct file action added.

## Changes

1. **Removed regex resolution from `BuildCustomEmulatorResult`** - CustomEmulatorProfile.Executable is now used directly
2. **Made `IsRegexPattern` more conservative** - Only detects unambiguous regex constructs (`[]`, `()`, `{}`, `|`, `^`, `$`)
3. **Kept regex handling for BuiltInEmulatorProfile** - Matches Playnite's behavior
4. **Don't add "Play (Direct)" for emulator games** - Skip `EnsureFileActionForExternalGame` if game has an Emulator action

## Testing

- All 179 tests pass
- Added test case for Windows path with `\duckstation\`

**Full Changelog**: https://github.com/hikaps/non-steam-sync/compare/develop...fix/emulator_paths