### PR TITLE
fix(steam): add tracking mode for emulator games

### DIFF
--- a/src/SteamShortcutsImporter/GameActionUtilities.cs
+++ b/src/SteamShortcutsImporter/GameActionUtilities.cs
@@ -7,7 +7,7 @@ namespace SteamShortcutsImporter;
 
 internal static class GameActionUtilities
 {
-    public static bool EnsureSteamLaunchAction(IList<GameAction>? existingActions, string expectedUrl, out List<GameAction> updatedActions, out GameAction steamAction)
+    public static bool EnsureSteamLaunchAction(IList<GameAction>? existingActions, string expectedUrl, string? trackingPath, out List<GameAction> updatedActions, out GameAction steamAction)
     {
         var actions = existingActions != null ? new List<GameAction>(existingActions) : new List<GameAction>();
         bool changed = false;
@@ -22,7 +22,9 @@ internal static class GameActionUtilities
             {
                 Name = Constants.PlaySteamActionName,
                 Type = GameActionType.URL,
-                Path = expectedUrl
+                Path = expectedUrl,
+                TrackingMode = TrackingMode.Directory,
+                TrackingPath = trackingPath
             };
             actions.Add(steam);
             changed = true;
@@ -44,6 +46,18 @@ internal static class GameActionUtilities
             if (!string.Equals(steam.Name, Constants.PlaySteamActionName, StringComparison.Ordinal))
             {
                 steam.Name = Constants.PlaySteamActionName;
+                changed = true;
+            }
+
+            if (steam.TrackingMode != TrackingMode.Directory)
+            {
+                steam.TrackingMode = TrackingMode.Directory;
+                changed = true;
+            }
+
+            if (!string.Equals(steam.TrackingPath, trackingPath, StringComparison.OrdinalIgnoreCase))
+            {
+                steam.TrackingPath = trackingPath;
                 changed = true;
             }
         }

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -806,7 +806,9 @@ internal class ImportExportService
             Path = expandedExe,
             Arguments = expandedArgs,
             WorkingDir = workDir,
-            IsPlayAction = emulatorAction.IsPlayAction
+            IsPlayAction = emulatorAction.IsPlayAction,
+            TrackingMode = TrackingMode.Directory,
+            TrackingPath = emulatorInstallDir
         };
 
         return (expandedExe, workDir, name, syntheticAction);
@@ -930,7 +932,9 @@ internal class ImportExportService
             Path = expandedExe,
             Arguments = expandedArgs,
             WorkingDir = workDir,
-            IsPlayAction = emulatorAction.IsPlayAction
+            IsPlayAction = emulatorAction.IsPlayAction,
+            TrackingMode = TrackingMode.Directory,
+            TrackingPath = emulatorInstallDir
         };
 
         return (expandedExe, workDir, name, syntheticAction);
@@ -999,7 +1003,9 @@ internal class ImportExportService
             Type = GameActionType.File,
             Path = exePath,
             WorkingDir = Path.GetDirectoryName(exePath),
-            IsPlayAction = game.GameActions == null || !game.GameActions.Any(a => a.IsPlayAction)
+            IsPlayAction = game.GameActions == null || !game.GameActions.Any(a => a.IsPlayAction),
+            TrackingMode = TrackingMode.Directory,
+            TrackingPath = Path.GetDirectoryName(exePath)
         };
 
         try
@@ -1121,7 +1127,7 @@ internal class ImportExportService
                 _library.EnsureFileActionForExternalGame(g, exePath, workDir, fileArgs);
             }
             
-            if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId); }
+            if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId, workDir); }
         }
         catch (Exception ex)
         {

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -418,6 +418,15 @@ public class ShortcutsLibrary : LibraryPlugin
 
     private GameAction BuildFilePlayAction(SteamShortcut sc, bool isDefault)
     {
+        // Derive tracking path from working directory or executable path
+        var trackingPath = sc.StartDir;
+        if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(sc.Exe))
+        {
+            try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"'));
+            }
+            catch { trackingPath = null; }
+        }
+
         return new GameAction
         {
             Name = Constants.PlayDirectActionName,
@@ -425,19 +434,31 @@ public class ShortcutsLibrary : LibraryPlugin
             Path = sc.Exe?.Trim('"'),
             Arguments = sc.LaunchOptions,
             WorkingDir = sc.StartDir,
-            IsPlayAction = isDefault
+            IsPlayAction = isDefault,
+            TrackingMode = TrackingMode.Directory,
+            TrackingPath = trackingPath
         };
     }
 
-    private GameAction BuildSteamUrlAction(uint appId, bool isDefault)
+    private GameAction BuildSteamUrlAction(SteamShortcut sc, bool isDefault)
     {
-        var gid = Utils.ToShortcutGameId(appId);
+        // Derive tracking path from working directory or executable path
+        var trackingPath = sc.StartDir;
+        if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(sc.Exe))
+        {
+            try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"')); }
+            catch { trackingPath = null; }
+        }
+
+        var gid = Utils.ToShortcutGameId(sc.AppId);
         return new GameAction
         {
             Name = Constants.PlaySteamActionName,
             Type = GameActionType.URL,
             Path = $"steam://rungameid/{gid}",
-            IsPlayAction = isDefault
+            IsPlayAction = isDefault,
+            TrackingMode = TrackingMode.Directory,
+            TrackingPath = trackingPath
         };
     }
 
@@ -447,8 +468,7 @@ public class ShortcutsLibrary : LibraryPlugin
         if (Settings.LaunchViaSteam && sc.AppId != 0)
         {
             // Steam URL default, keep direct exe as secondary
-            actions.Add(BuildSteamUrlAction(sc.AppId, isDefault: true));
-            actions.Add(BuildFilePlayAction(sc, isDefault: false));
+            actions.Add(BuildSteamUrlAction(sc, isDefault: true));
         }
         else
         {
@@ -485,7 +505,7 @@ public class ShortcutsLibrary : LibraryPlugin
         }
     }
 
-    internal void EnsureSteamPlayActionForExternalGame(Game game, uint appId)
+    internal void EnsureSteamPlayActionForExternalGame(Game game, uint appId, string? trackingPath = null)
     {
         if (appId == 0)
         {
@@ -494,7 +514,9 @@ public class ShortcutsLibrary : LibraryPlugin
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}{Utils.ToShortcutGameId(appId)}";
         var existing = game.GameActions as IList<GameAction>;
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(existing, expectedUrl, out var updated, out _);
+        // Use provided tracking path, or fall back to game's install directory
+        var effectiveTrackingPath = trackingPath ?? game.InstallDirectory;
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(existing, expectedUrl, effectiveTrackingPath, out var updated, out _);
         if (!changed)
         {
             return;

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -422,9 +422,8 @@ public class ShortcutsLibrary : LibraryPlugin
         var trackingPath = sc.StartDir;
         if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(sc.Exe))
         {
-            try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"'));
-            }
-            catch { trackingPath = null; }
+            try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"')); }
+			catch (Exception ex) { Logger.Warn(ex, $"Failed to derive tracking path from exe for '{sc.AppName}'"); trackingPath = null; }
         }
 
         return new GameAction
@@ -446,8 +445,8 @@ public class ShortcutsLibrary : LibraryPlugin
         var trackingPath = sc.StartDir;
         if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(sc.Exe))
         {
-            try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"')); }
-            catch { trackingPath = null; }
+try { trackingPath = System.IO.Path.GetDirectoryName(sc.Exe?.Trim('"')); }
+		catch (Exception ex) { Logger.Warn(ex, $"Failed to derive tracking path from exe for '{sc.AppName}'"); trackingPath = null; }
         }
 
         var gid = Utils.ToShortcutGameId(sc.AppId);

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -231,8 +231,8 @@ internal class WriteBackHandler : IDisposable
                 var trackingPath = sc.StartDir;
                 if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(directExe))
                 {
-                    try { trackingPath = System.IO.Path.GetDirectoryName(directExe); }
-                    catch { trackingPath = null; }
+try { trackingPath = System.IO.Path.GetDirectoryName(directExe); }
+				catch (Exception ex) { _logger.Warn(ex, $"Failed to derive tracking path from exe for '{sc.AppName}'"); trackingPath = null; }
                 }
 
                 newActions.Add(new GameAction

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -226,12 +226,23 @@ internal class WriteBackHandler : IDisposable
                 }
 
                 var directArgs = EmulatorPathUtils.QuoteArgumentsIfNeeded(sc.LaunchOptions);
+
+                // Derive tracking path from working directory or executable path
+                var trackingPath = sc.StartDir;
+                if (string.IsNullOrWhiteSpace(trackingPath) && !string.IsNullOrWhiteSpace(directExe))
+                {
+                    try { trackingPath = System.IO.Path.GetDirectoryName(directExe); }
+                    catch { trackingPath = null; }
+                }
+
                 newActions.Add(new GameAction
                 {
                     Name = Constants.PlaySteamActionName,
                     Type = GameActionType.URL,
                     Path = expectedUrl,
-                    IsPlayAction = true
+                    IsPlayAction = true,
+                    TrackingMode = TrackingMode.Directory,
+                    TrackingPath = trackingPath
                 });
                 newActions.Add(new GameAction
                 {
@@ -240,7 +251,9 @@ internal class WriteBackHandler : IDisposable
                     Path = directExe,
                     Arguments = directArgs,
                     WorkingDir = sc.StartDir,
-                    IsPlayAction = false
+                    IsPlayAction = false,
+                    TrackingMode = TrackingMode.Directory,
+                    TrackingPath = trackingPath
                 });
                 
                 game.GameActions = new System.Collections.ObjectModel.ObservableCollection<GameAction>(newActions);

--- a/tests/ShortcutsTests/SteamActionUtilitiesTests.cs
+++ b/tests/ShortcutsTests/SteamActionUtilitiesTests.cs
@@ -19,13 +19,16 @@ public class SteamActionUtilitiesTests
         };
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}123456";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, out var updated, out var steamAction);
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, trackingPath, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(Constants.PlaySteamActionName, steamAction.Name);
         Assert.Equal(GameActionType.URL, steamAction.Type);
         Assert.Equal(expectedUrl, steamAction.Path);
         Assert.True(steamAction.IsPlayAction);
+        Assert.Equal(TrackingMode.Directory, steamAction.TrackingMode);
+        Assert.Equal(trackingPath, steamAction.TrackingPath);
         Assert.Equal(2, updated.Count);
         Assert.Same(fileAction, updated[1]);
         Assert.False(fileAction.IsPlayAction);
@@ -43,9 +46,10 @@ public class SteamActionUtilitiesTests
         };
 
         var expectedUrl = existingSteam.Path;
+        var trackingPath = @"C:\Games";
         var otherAction = new GameAction { Name = "Custom", Type = GameActionType.File, Path = "custom.exe", IsPlayAction = true };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherAction, existingSteam }, expectedUrl, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherAction, existingSteam }, expectedUrl, trackingPath, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Same(existingSteam, steamAction);
@@ -61,11 +65,12 @@ public class SteamActionUtilitiesTests
     public void RemovesDuplicateSteamActionsWithSamePath()
     {
         var expectedUrl = $"{Constants.SteamRungameIdUrl}246810";
+        var trackingPath = @"C:\Games";
         var steamA = new GameAction { Name = "Play (Steam)", Type = GameActionType.URL, Path = expectedUrl, IsPlayAction = true };
         var steamB = new GameAction { Name = "Play (Steam)", Type = GameActionType.URL, Path = expectedUrl, IsPlayAction = false };
         var other = new GameAction { Name = "Something Else", Type = GameActionType.File, Path = "run.exe" };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { steamA, steamB, other }, expectedUrl, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { steamA, steamB, other }, expectedUrl, trackingPath, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Single(updated.Where(a => a.Type == GameActionType.URL && a.Path == expectedUrl));
@@ -77,6 +82,7 @@ public class SteamActionUtilitiesTests
     public void KeepsOtherSteamActionsWithDifferentTargets()
     {
         var expectedUrl = $"{Constants.SteamRungameIdUrl}100200";
+        var trackingPath = @"C:\Games";
         var otherSteam = new GameAction
         {
             Name = "Official Steam",
@@ -85,7 +91,7 @@ public class SteamActionUtilitiesTests
             IsPlayAction = false
         };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherSteam }, expectedUrl, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherSteam }, expectedUrl, trackingPath, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(2, updated.Count);


### PR DESCRIPTION
## Summary
- Set `TrackingMode.Directory` and `TrackingPath` on all `GameAction` objects created by the plugin
- Follows Playnite's official FAQ recommendation for tracking non-Steam games

## Problem
Emulator games get stuck during tracking because Playnite's default tracking mode fails to detect when the emulator process is running. The game executable points to the ROM file, not the actual process that needs to be tracked.

## Solution
Set `TrackingMode.Directory` ("Folder" in UI) and `TrackingPath` to the appropriate folder:
- **Emulator games**: emulator installation directory
- **Steam shortcut imports**: shortcut's `StartDir` or executable directory
- **Discovered executables**: directory of the executable

## Files Changed
- `ShortcutsLibrary.cs` - `BuildFilePlayAction()` now derives `TrackingPath` from `StartDir` or exe path
- `ImportExportService.cs` - `BuildCustomEmulatorResult()` and `BuildBuiltInEmulatorResult()` set tracking for emulator games
- `ImportExportService.cs` - `CreateAndPersistFileAction()` sets tracking for discovered executables

Fixes #21