### PR TITLE
fix(core): normalize double backslashes in emulated game paths

### DIFF
--- a/src/SteamShortcutsImporter/EmulatorPathUtils.cs
+++ b/src/SteamShortcutsImporter/EmulatorPathUtils.cs
@@ -7,6 +7,26 @@ namespace SteamShortcutsImporter;
 
 internal static class EmulatorPathUtils
 {
+    /// <summary>
+    /// Matches two or more consecutive backslashes that are preceded by a non-separator,
+    /// non-quote, non-whitespace character. This collapses double backslashes from path
+    /// concatenation (e.g., "C:\Games\\" + "\file.iso") while preserving UNC path prefixes
+    /// like \\server\share (which follow whitespace or quotes).
+    /// </summary>
+    private static readonly Regex MultipleBackslashRegex = new Regex(
+        @"(?<=[^\\/""\s])\\{2,}",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Normalizes path separators by collapsing consecutive backslashes to a single backslash.
+    /// Preserves UNC path prefixes (\\server\share) at the start of path segments.
+    /// </summary>
+    public static string NormalizePathSeparators(string? input)
+    {
+        if (string.IsNullOrEmpty(input)) return input ?? string.Empty;
+        return MultipleBackslashRegex.Replace(input, @"\");
+    }
+
     public static bool IsRegexPattern(string? s)
     {
         if (string.IsNullOrEmpty(s))
@@ -43,6 +63,9 @@ internal static class EmulatorPathUtils
         {
             return string.Empty;
         }
+
+        // Normalize double backslashes from path concatenation (e.g., InstallDir trailing \ + filename leading \)
+        args = NormalizePathSeparators(args);
 
         var trimmed = args.Trim();
         if (trimmed.Length == 0)

--- a/src/SteamShortcutsImporter/SteamPathResolver.cs
+++ b/src/SteamShortcutsImporter/SteamPathResolver.cs
@@ -164,7 +164,7 @@ internal class SteamPathResolver
                 }
             }
 
-            return unquoted;
+            return EmulatorPathUtils.NormalizePathSeparators(unquoted);
         }
         catch (Exception ex)
         {

--- a/tests/ShortcutsTests/EmulatorPathUtilsTests.cs
+++ b/tests/ShortcutsTests/EmulatorPathUtilsTests.cs
@@ -196,4 +196,117 @@ public class EmulatorPathUtilsTests
     }
 
     #endregion
+
+    #region NormalizePathSeparators Tests
+
+    [Fact]
+    public void NormalizePathSeparators_WithNull_ReturnsEmpty()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(null);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_WithEmpty_ReturnsEmpty()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators("");
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_NoDoubleBackslash_ReturnsAsIs()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"C:\Games\ROMs\game.iso");
+        Assert.Equal(@"C:\Games\ROMs\game.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_DoubleBackslash_CollapsesToSingle()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"C:\Games\\ROMs\game.iso");
+        Assert.Equal(@"C:\Games\ROMs\game.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_PCSX2Scenario_TrailingBackslash()
+    {
+        // Simulates: InstallDir = "X:\Folder1\Folder2\" + filename = "\Resident Evil.iso"
+        var result = EmulatorPathUtils.NormalizePathSeparators(
+            @"-batch -slowboot -- X:\Folder1\Folder2\\Resident Evil - Outbreak (USA) (v2.00).iso");
+        Assert.Equal(@"-batch -slowboot -- X:\Folder1\Folder2\Resident Evil - Outbreak (USA) (v2.00).iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_TripleBackslash_CollapsesToSingle()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"C:\Games\\\ROMs\game.iso");
+        Assert.Equal(@"C:\Games\ROMs\game.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_MultipleDoubleBackslashes_AllCollapsed()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"C:\Games\\ROMs\\PS2\game.iso");
+        Assert.Equal(@"C:\Games\ROMs\PS2\game.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_UNCPathPrefix_Preserved()
+    {
+        // UNC path: \\server\share should keep its double backslash prefix
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"\\server\share\file.iso");
+        Assert.Equal(@"\\server\share\file.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_UNCPathInArguments_Preserved()
+    {
+        // UNC path after flags: -- \\server\share should keep its prefix
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"-- \\server\share\file.iso");
+        Assert.Equal(@"-- \\server\share\file.iso", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_UNCPathInQuotes_Preserved()
+    {
+        // UNC path in quotes: "\\server\share" should keep its prefix
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"""\\server\share\file.iso""");
+        Assert.Equal(@"""\\server\share\file.iso""", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_QuotedPathWithDoubleBackslash_Collapsed()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"""C:\Games\\My Game\rom.gb""");
+        Assert.Equal(@"""C:\Games\My Game\rom.gb""", result);
+    }
+
+    [Fact]
+    public void NormalizePathSeparators_ArgumentsWithQuotedPath_Collapsed()
+    {
+        var result = EmulatorPathUtils.NormalizePathSeparators(@"-f ""C:\path with space\\file.rom""");
+        Assert.Equal(@"-f ""C:\path with space\file.rom""", result);
+    }
+
+    #endregion
+
+    #region QuoteArgumentsIfNeeded with Normalization Tests
+
+    [Fact]
+    public void QuoteArgumentsIfNeeded_DoubleBackslashInPath_CollapsesAndQuotes()
+    {
+        // Path with double backslash and spaces should normalize then quote
+        var result = EmulatorPathUtils.QuoteArgumentsIfNeeded(
+            @"-batch -slowboot -- X:\Folder1\Folder2\\Resident Evil.iso");
+        Assert.Equal(@"-batch -slowboot -- X:\Folder1\Folder2\Resident Evil.iso", result);
+    }
+
+    [Fact]
+    public void QuoteArgumentsIfNeeded_DoubleBackslashSimplePath_Collapses()
+    {
+        var result = EmulatorPathUtils.QuoteArgumentsIfNeeded(@"C:\Games\\ROMs\Game Boy\\Pokemon Red.gb");
+        Assert.Equal(@"""C:\Games\ROMs\Game Boy\Pokemon Red.gb""", result);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Add `NormalizePathSeparators()` to `EmulatorPathUtils` that collapses consecutive backslashes in expanded paths, preserving UNC path prefixes
- Integrate normalization into `QuoteArgumentsIfNeeded` (covers all 5 argument expansion paths) and `SteamPathResolver.ExpandPathVariables` (covers exe/workDir paths)
- Add 14 tests covering double/triple backslash collapse, UNC preservation, quoted paths, and the PCSX2 scenario

## Problem

When creating a Steam entry for PCSX2 (and potentially other emulators), the launch options contain double backslashes in the file path:

```
-batch -slowboot -- X:\Folder1\Folder2\\Resident Evil - Outbreak (USA) (v2.00).iso
```

This happens because Playnite InstallDir always has a trailing `\`, and the ROM path has a leading `\`. Most emulators handle this gracefully, but PCSX2 treats `\\` as a literal path component and throws "file not found".

## Fix

Normalization runs via regex `(?<=[^\\/""\s])\\{2,}` which collapses 2+ consecutive backslashes to one, preserving UNC path prefixes that appear after spaces or quotes.

All 5 code paths that expand variables now normalize:
- Custom emulator args (`ImportExportService.cs` ~789)
- Built-in emulator args (`ImportExportService.cs` ~919)
- File action export (`ImportExportService.cs` ~1070)
- Update game actions (`ImportExportService.cs` ~1125)
- Write-back sync (`WriteBackHandler.cs` ~165)
- Exe/workDir paths (`SteamPathResolver.cs` ~167)

Closes #23

## Test plan

- [x] 199/199 existing tests pass with no regressions
- [x] 14 new tests added for `NormalizePathSeparators` and its integration
- [x] Manual test: export a PCSX2 game to Steam and verify launch options have single backslashes