### PR TITLE
LaunchViaSteam setting missing from WriteBackHandler in EnsureSteamPlayAction

### DIFF
--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -204,7 +204,7 @@ internal class WriteBackHandler : IDisposable
         {
             // This method is only used internally within WriteBackHandler
             // Check if steam launch is enabled and if the shortcut has an AppId
-            if (sc.AppId == 0)
+            if (!_settings.LaunchViaSteam || sc.AppId == 0)
             {
                 return;
             }


### PR DESCRIPTION
Expanded the early return logic to also check if LaunchViaSteam is disabled in settings, in addition to checking if AppId is 0. This prevents further processing when Steam launch is not enabled.