### PR TITLE
fix(steam): make Steam action default toggleable

### DIFF
--- a/src/SteamShortcutsImporter/GameActionUtilities.cs
+++ b/src/SteamShortcutsImporter/GameActionUtilities.cs
@@ -9,7 +9,7 @@ namespace SteamShortcutsImporter;
 
 internal static class GameActionUtilities
 {
-    public static bool EnsureSteamLaunchAction(IList<GameAction>? existingActions, string expectedUrl, string? trackingPath, out List<GameAction> updatedActions, out GameAction steamAction)
+    public static bool EnsureSteamLaunchAction(IList<GameAction>? existingActions, string expectedUrl, string? trackingPath, bool steamActionIsDefault, out List<GameAction> updatedActions, out GameAction steamAction)
     {
         var actions = existingActions != null ? new List<GameAction>(existingActions) : new List<GameAction>();
         bool changed = false;
@@ -76,20 +76,47 @@ internal static class GameActionUtilities
             changed = true;
         }
 
-        for (int i = 0; i < actions.Count; i++)
+        if (steamActionIsDefault)
         {
-            var act = actions[i];
-            if (!ReferenceEquals(act, steam) && act.IsPlayAction)
+            for (int i = 0; i < actions.Count; i++)
             {
-                act.IsPlayAction = false;
+                var act = actions[i];
+                if (!ReferenceEquals(act, steam) && act.IsPlayAction)
+                {
+                    act.IsPlayAction = false;
+                    changed = true;
+                }
+            }
+
+            if (!steam.IsPlayAction)
+            {
+                steam.IsPlayAction = true;
                 changed = true;
             }
         }
-
-        if (!steam.IsPlayAction)
+        else
         {
-            steam.IsPlayAction = true;
-            changed = true;
+            // Steam is not the intended default. Promote a File action (Play (Direct)) as the
+            // active play action so Playnite's Installation Status Updater can track the install
+            // folder. Fall back to Steam only when no File action exists.
+            var fileDefault = actions.FirstOrDefault(a =>
+                    !ReferenceEquals(a, steam) &&
+                    a.Type == GameActionType.File &&
+                    string.Equals(a.Name, Constants.PlayDirectActionName, StringComparison.Ordinal))
+                ?? actions.FirstOrDefault(a => !ReferenceEquals(a, steam) && a.Type == GameActionType.File);
+
+            var desiredDefault = fileDefault ?? steam;
+
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var act = actions[i];
+                var shouldBeDefault = ReferenceEquals(act, desiredDefault);
+                if (act.IsPlayAction != shouldBeDefault)
+                {
+                    act.IsPlayAction = shouldBeDefault;
+                    changed = true;
+                }
+            }
         }
 
         if (actions.Count == 0 || !ReferenceEquals(actions.First(), steam))

--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -1127,7 +1127,7 @@ internal class ImportExportService
                 _library.EnsureFileActionForExternalGame(g, exePath, workDir, fileArgs);
             }
             
-            if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId, workDir); }
+            if (_library.Settings.LaunchViaSteam && appId != 0) { _library.EnsureSteamPlayActionForExternalGame(g, appId, workDir, _library.Settings.SteamActionIsDefault); }
         }
         catch (Exception ex)
         {

--- a/src/SteamShortcutsImporter/PluginSettings.cs
+++ b/src/SteamShortcutsImporter/PluginSettings.cs
@@ -12,19 +12,32 @@ namespace SteamShortcutsImporter;
 public class PluginSettings : ISettings
 {
     private readonly LibraryPlugin? _plugin;
+    private bool _originalSteamActionIsDefault;
 
     public string SteamRootPath { get; set; } = string.Empty;
     public bool LaunchViaSteam { get; set; } = true;
+    public bool SteamActionIsDefault { get; set; } = true;
     public string? SelectedSteamUserId { get; set; } = null;
     public Dictionary<string, string> ExportMap { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-    public void BeginEdit() { }
+    public void BeginEdit() { _originalSteamActionIsDefault = SteamActionIsDefault; }
     public void CancelEdit() { }
     public void EndEdit()
     {
         if (_plugin != null)
         {
             _plugin.SavePluginSettings(this);
+            if (SteamActionIsDefault != _originalSteamActionIsDefault)
+            {
+                try
+                {
+                    ShortcutsLibrary.ReapplyPlayActionsForAllGames();
+                }
+                catch (Exception ex)
+                {
+                    LogManager.GetLogger().Error(ex, "Failed to reapply play actions after SteamActionIsDefault change.");
+                }
+            }
         }
     }
 
@@ -50,6 +63,7 @@ public class PluginSettings : ISettings
             {
                 SteamRootPath = saved.SteamRootPath;
                 LaunchViaSteam = saved.LaunchViaSteam;
+                SteamActionIsDefault = saved.SteamActionIsDefault;
                 SelectedSteamUserId = saved.SelectedSteamUserId;
                 ExportMap = saved.ExportMap ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
@@ -57,6 +71,7 @@ public class PluginSettings : ISettings
             {
                 SteamRootPath = GuessSteamRootPath() ?? string.Empty;
                 LaunchViaSteam = true;
+                SteamActionIsDefault = true;
                 SelectedSteamUserId = null;
                 ExportMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
@@ -66,6 +81,7 @@ public class PluginSettings : ISettings
             LogManager.GetLogger().Error(ex, "Failed to load saved settings, falling back to defaults.");
             SteamRootPath = GuessSteamRootPath() ?? string.Empty;
             LaunchViaSteam = true;
+            SteamActionIsDefault = true;
             SelectedSteamUserId = null;
             ExportMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }

--- a/src/SteamShortcutsImporter/PluginSettingsView.cs
+++ b/src/SteamShortcutsImporter/PluginSettingsView.cs
@@ -15,6 +15,8 @@ public class PluginSettingsView : UserControl
     private TextBox? _pathBox;
     private TextBlock? _validationText;
     private TextBlock? _validationInfo;
+    private CheckBox? _launchCheck;
+    private CheckBox? _steamDefaultCheckBox;
     private ComboBox? _userComboBox;
     private string? _currentSteamRootPath;
     private bool _isRefreshingUsers;
@@ -95,14 +97,30 @@ public class PluginSettingsView : UserControl
         panel.Children.Add(_validationInfo);
 
         // Launch via Steam checkbox
-        var launchCheck = new CheckBox
+        _launchCheck = new CheckBox
         {
             Content = "Launch via Steam (rungameid) when possible",
             Margin = new Thickness(0, 12, 0, 0)
         };
-        launchCheck.SetBinding(System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty,
+        _launchCheck.SetBinding(System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty,
             new System.Windows.Data.Binding("LaunchViaSteam") { Mode = System.Windows.Data.BindingMode.TwoWay });
-        panel.Children.Add(launchCheck);
+        _launchCheck.Checked += LaunchCheck_IsEnabledChanged;
+        _launchCheck.Unchecked += LaunchCheck_IsEnabledChanged;
+        panel.Children.Add(_launchCheck);
+
+        // Steam default action checkbox (indented under Launch via Steam)
+        _steamDefaultCheckBox = new CheckBox
+        {
+            Content = "Make Steam action the default play action",
+            Margin = new Thickness(24, 4, 0, 0),
+            IsEnabled = false
+        };
+        _steamDefaultCheckBox.SetBinding(System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty,
+            new System.Windows.Data.Binding("SteamActionIsDefault") { Mode = System.Windows.Data.BindingMode.TwoWay });
+        panel.Children.Add(_steamDefaultCheckBox);
+
+        // Set initial enabled state for default checkbox
+        Loaded += InitializeDefaultCheckBoxState;
 
         // Steam user selection
         panel.Children.Add(new TextBlock
@@ -481,6 +499,22 @@ public class PluginSettingsView : UserControl
         if (settings != null)
         {
             settings.SelectedSteamUserId = selectedItem?.Tag as string;
+        }
+    }
+
+    private void LaunchCheck_IsEnabledChanged(object sender, RoutedEventArgs e)
+    {
+        if (_steamDefaultCheckBox != null && _launchCheck != null)
+        {
+            _steamDefaultCheckBox.IsEnabled = _launchCheck.IsChecked == true;
+        }
+    }
+
+    private void InitializeDefaultCheckBoxState(object sender, RoutedEventArgs e)
+    {
+        if (_steamDefaultCheckBox != null && _launchCheck != null)
+        {
+            _steamDefaultCheckBox.IsEnabled = _launchCheck.IsChecked == true;
         }
     }
 }

--- a/src/SteamShortcutsImporter/ShortcutsLibrary.cs
+++ b/src/SteamShortcutsImporter/ShortcutsLibrary.cs
@@ -448,9 +448,9 @@ public class ShortcutsLibrary : LibraryPlugin
         var actions = new List<GameAction>();
         if (Settings.LaunchViaSteam && sc.AppId != 0)
         {
-            // Steam URL default, keep direct exe as secondary
-            actions.Add(BuildSteamUrlAction(sc, isDefault: true));
-            actions.Add(BuildFilePlayAction(sc, isDefault: false));
+            var steamIsDefault = Settings.SteamActionIsDefault;
+            actions.Add(BuildSteamUrlAction(sc, isDefault: steamIsDefault));
+            actions.Add(BuildFilePlayAction(sc, isDefault: !steamIsDefault));
         }
         else
         {
@@ -471,7 +471,7 @@ public class ShortcutsLibrary : LibraryPlugin
 
             var expectedUrl = $"{Constants.SteamRungameIdUrl}{Utils.ToShortcutGameId(sc.AppId)}";
             var trackingPath = GameActionUtilities.DeriveTrackingPath(sc.StartDir, sc.Exe, Logger, sc.AppName);
-            var changed = GameActionUtilities.EnsureSteamLaunchAction(game.GameActions as IList<GameAction>, expectedUrl, trackingPath, out var updated, out _);
+            var changed = GameActionUtilities.EnsureSteamLaunchAction(game.GameActions as IList<GameAction>, expectedUrl, trackingPath, Settings.SteamActionIsDefault, out var updated, out _);
             if (!changed)
             {
                 return;
@@ -487,7 +487,7 @@ public class ShortcutsLibrary : LibraryPlugin
         }
     }
 
-    internal void EnsureSteamPlayActionForExternalGame(Game game, uint appId, string? trackingPath = null)
+    internal void EnsureSteamPlayActionForExternalGame(Game game, uint appId, string? trackingPath = null, bool? steamActionIsDefault = null)
     {
         if (appId == 0)
         {
@@ -498,7 +498,8 @@ public class ShortcutsLibrary : LibraryPlugin
         var existing = game.GameActions as IList<GameAction>;
         // Use provided tracking path, or fall back to game's install directory
         var effectiveTrackingPath = trackingPath ?? game.InstallDirectory;
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(existing, expectedUrl, effectiveTrackingPath, out var updated, out _);
+        var effectiveIsDefault = steamActionIsDefault ?? Settings.SteamActionIsDefault;
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(existing, expectedUrl, effectiveTrackingPath, effectiveIsDefault, out var updated, out _);
         if (!changed)
         {
             return;
@@ -533,5 +534,56 @@ public class ShortcutsLibrary : LibraryPlugin
         }
     }
 
+    public static void ReapplyPlayActionsForAllGames()
+    {
+        var instance = Instance;
+        if (instance == null) return;
+
+        try
+        {
+            var games = instance.PlayniteApi.Database.Games
+                .Where(g => g.GameActions != null && g.GameActions.Any(a =>
+                    a.Type == GameActionType.URL &&
+                    string.Equals(a.Name, Constants.PlaySteamActionName, StringComparison.Ordinal)))
+                .ToList();
+
+            foreach (var game in games)
+            {
+                try
+                {
+                    var steamAction = game.GameActions?.FirstOrDefault(a =>
+                        a.Type == GameActionType.URL &&
+                        a.Name == Constants.PlaySteamActionName);
+
+                    if (steamAction == null) continue;
+
+                    var expectedUrl = steamAction.Path;
+                    var trackingPath = steamAction.TrackingPath ?? game.InstallDirectory;
+
+                    var changed = GameActionUtilities.EnsureSteamLaunchAction(
+                        game.GameActions as IList<GameAction>,
+                        expectedUrl,
+                        trackingPath,
+                        instance.Settings.SteamActionIsDefault,
+                        out var updated,
+                        out _);
+
+                    if (changed)
+                    {
+                        game.GameActions = new System.Collections.ObjectModel.ObservableCollection<GameAction>(updated);
+                        instance.PlayniteApi.Database.Games.Update(game);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, $"Failed to reapply play actions for game '{game.Name}'");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to reapply play actions for all games.");
+        }
+    }
 
 }

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -211,7 +211,7 @@ internal class WriteBackHandler : IDisposable
 
             var expectedUrl = $"{Constants.SteamRungameIdUrl}{Utils.ToShortcutGameId(sc.AppId)}";
             var trackingPath = GameActionUtilities.DeriveTrackingPath(sc.StartDir, sc.Exe?.Trim('"'), _logger, sc.AppName);
-            var changed = GameActionUtilities.EnsureSteamLaunchAction(game.GameActions as IList<GameAction>, expectedUrl, trackingPath, out var updated, out _);
+            var changed = GameActionUtilities.EnsureSteamLaunchAction(game.GameActions as IList<GameAction>, expectedUrl, trackingPath, _settings.SteamActionIsDefault, out var updated, out _);
             if (!changed)
             {
                 return;

--- a/tests/ShortcutsTests/SteamActionUtilitiesTests.cs
+++ b/tests/ShortcutsTests/SteamActionUtilitiesTests.cs
@@ -20,7 +20,7 @@ public class SteamActionUtilitiesTests
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}123456";
         var trackingPath = @"C:\Games";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(Constants.PlaySteamActionName, steamAction.Name);
@@ -49,7 +49,7 @@ public class SteamActionUtilitiesTests
         var trackingPath = @"C:\Games";
         var otherAction = new GameAction { Name = "Custom", Type = GameActionType.File, Path = "custom.exe", IsPlayAction = true };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherAction, existingSteam }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherAction, existingSteam }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Same(existingSteam, steamAction);
@@ -70,7 +70,7 @@ public class SteamActionUtilitiesTests
         var steamB = new GameAction { Name = "Play (Steam)", Type = GameActionType.URL, Path = expectedUrl, IsPlayAction = false };
         var other = new GameAction { Name = "Something Else", Type = GameActionType.File, Path = "run.exe" };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { steamA, steamB, other }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { steamA, steamB, other }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Single(updated.Where(a => a.Type == GameActionType.URL && a.Path == expectedUrl));
@@ -91,7 +91,7 @@ public class SteamActionUtilitiesTests
             IsPlayAction = false
         };
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherSteam }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { otherSteam }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(2, updated.Count);
@@ -116,7 +116,7 @@ public class SteamActionUtilitiesTests
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}555666";
         var trackingPath = @"C:\Tracking";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(2, updated.Count);
@@ -141,7 +141,7 @@ public class SteamActionUtilitiesTests
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}777888";
         var trackingPath = @"C:\Games";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction, urlAction, customAction }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { fileAction, urlAction, customAction }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Equal(4, updated.Count);
@@ -157,7 +157,7 @@ public class SteamActionUtilitiesTests
         var expectedUrl = $"{Constants.SteamRungameIdUrl}111222";
         var trackingPath = @"C:\Games";
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(null, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(null, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Single(updated);
@@ -170,7 +170,7 @@ public class SteamActionUtilitiesTests
         var expectedUrl = $"{Constants.SteamRungameIdUrl}333444";
         var trackingPath = @"C:\Games";
 
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction>(), expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction>(), expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Single(updated);
@@ -191,7 +191,7 @@ public class SteamActionUtilitiesTests
         };
 
         var trackingPath = @"C:\New";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { existingSteam }, existingSteam.Path, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { existingSteam }, existingSteam.Path, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Same(existingSteam, steamAction);
@@ -216,7 +216,7 @@ public class SteamActionUtilitiesTests
 
         var expectedUrl = $"{Constants.SteamRungameIdUrl}444555";
         var trackingPath = @"C:\Tracking";
-        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { action }, expectedUrl, trackingPath, out var updated, out var steamAction);
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(new List<GameAction> { action }, expectedUrl, trackingPath, steamActionIsDefault: true, out var updated, out var steamAction);
 
         Assert.True(changed);
         Assert.Same(action, updated[1]);
@@ -229,5 +229,186 @@ public class SteamActionUtilitiesTests
         Assert.Equal(@"C:\Games\primary.exe", action.TrackingPath);
         Assert.False(action.IsPlayAction);
         Assert.Same(steamAction, updated[0]);
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_KeepsFileActionAsDefault()
+    {
+        var fileAction = new GameAction
+        {
+            Name = "Play",
+            Type = GameActionType.File,
+            Path = "game.exe",
+            IsPlayAction = true
+        };
+
+        var expectedUrl = $"{Constants.SteamRungameIdUrl}123456";
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { fileAction }, expectedUrl, trackingPath, false, out var updated, out var steamAction);
+
+        Assert.True(changed);
+        Assert.Equal(Constants.PlaySteamActionName, steamAction.Name);
+        Assert.False(steamAction.IsPlayAction);
+        Assert.True(fileAction.IsPlayAction);
+        Assert.Equal(2, updated.Count);
+        Assert.Same(steamAction, updated[0]);
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_WhenNoExistingDefault_MakesSteamDefault()
+    {
+        var otherAction = new GameAction
+        {
+            Name = "Info",
+            Type = GameActionType.URL,
+            Path = "https://example.com",
+            IsPlayAction = false
+        };
+
+        var expectedUrl = $"{Constants.SteamRungameIdUrl}789012";
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { otherAction }, expectedUrl, trackingPath, false, out var updated, out var steamAction);
+
+        Assert.True(changed);
+        Assert.True(steamAction.IsPlayAction);
+        Assert.False(otherAction.IsPlayAction);
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_PreservesExistingDefault()
+    {
+        var actionA = new GameAction
+        {
+            Name = "Primary",
+            Type = GameActionType.File,
+            Path = "game.exe",
+            IsPlayAction = true
+        };
+        var actionB = new GameAction
+        {
+            Name = "Website",
+            Type = GameActionType.URL,
+            Path = "https://example.com",
+            IsPlayAction = false
+        };
+
+        var expectedUrl = $"{Constants.SteamRungameIdUrl}345678";
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { actionA, actionB }, expectedUrl, trackingPath, false, out var updated, out var steamAction);
+
+        Assert.True(changed);
+        Assert.True(actionA.IsPlayAction);
+        Assert.False(actionB.IsPlayAction);
+        Assert.False(steamAction.IsPlayAction);
+    }
+
+    [Fact]
+    public void SteamActionIsDefault_True_BehavesSameAsBefore()
+    {
+        var fileAction = new GameAction
+        {
+            Name = "Play",
+            Type = GameActionType.File,
+            Path = "game.exe",
+            IsPlayAction = true
+        };
+
+        var expectedUrl = $"{Constants.SteamRungameIdUrl}555666";
+        var trackingPath = @"C:\Tracking";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { fileAction }, expectedUrl, trackingPath, true, out var updated, out var steamAction);
+
+        Assert.True(changed);
+        Assert.Equal(2, updated.Count);
+        Assert.Same(steamAction, updated[0]);
+        Assert.Same(fileAction, updated[1]);
+        Assert.True(steamAction.IsPlayAction);
+        Assert.False(fileAction.IsPlayAction);
+        Assert.Equal(Constants.PlaySteamActionName, steamAction.Name);
+        Assert.Equal(GameActionType.URL, steamAction.Type);
+        Assert.Equal(expectedUrl, steamAction.Path);
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_DemotesSteamAndPromotesFile()
+    {
+        // State every game imported under the old default-on setting is in.
+        var steamAction = new GameAction
+        {
+            Name = Constants.PlaySteamActionName,
+            Type = GameActionType.URL,
+            Path = $"{Constants.SteamRungameIdUrl}654321",
+            IsPlayAction = true
+        };
+        var fileAction = new GameAction
+        {
+            Name = Constants.PlayDirectActionName,
+            Type = GameActionType.File,
+            Path = "game.exe",
+            IsPlayAction = false
+        };
+
+        var expectedUrl = steamAction.Path;
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { steamAction, fileAction }, expectedUrl, trackingPath, false, out var updated, out var resultSteam);
+
+        Assert.True(changed);
+        Assert.False(resultSteam.IsPlayAction);
+        Assert.True(fileAction.IsPlayAction);
+        Assert.Single(updated.Where(a => a.IsPlayAction));
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_ResolvesDoubleDefaultToFile()
+    {
+        var steamAction = new GameAction
+        {
+            Name = Constants.PlaySteamActionName,
+            Type = GameActionType.URL,
+            Path = $"{Constants.SteamRungameIdUrl}654322",
+            IsPlayAction = true
+        };
+        var fileAction = new GameAction
+        {
+            Name = Constants.PlayDirectActionName,
+            Type = GameActionType.File,
+            Path = "game.exe",
+            IsPlayAction = true
+        };
+
+        var expectedUrl = steamAction.Path;
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { steamAction, fileAction }, expectedUrl, trackingPath, false, out var updated, out _);
+
+        Assert.True(changed);
+        Assert.False(steamAction.IsPlayAction);
+        Assert.True(fileAction.IsPlayAction);
+        Assert.Single(updated.Where(a => a.IsPlayAction));
+    }
+
+    [Fact]
+    public void SteamActionNotDefault_NoFileAction_KeepsSteamAsDefault()
+    {
+        var steamAction = new GameAction
+        {
+            Name = Constants.PlaySteamActionName,
+            Type = GameActionType.URL,
+            Path = $"{Constants.SteamRungameIdUrl}654323",
+            IsPlayAction = true
+        };
+
+        var expectedUrl = steamAction.Path;
+        var trackingPath = @"C:\Games";
+        var changed = GameActionUtilities.EnsureSteamLaunchAction(
+            new List<GameAction> { steamAction }, expectedUrl, trackingPath, false, out var updated, out _);
+
+        // No File action to promote; Steam stays the default so the game remains launchable.
+        Assert.True(changed);
+        Assert.True(steamAction.IsPlayAction);
     }
 }


### PR DESCRIPTION
## Summary

Adds a `SteamActionIsDefault` setting so users can keep the original **Play (Direct)** file action as the active play action instead of always forcing **Play (Steam)** as the default. This restores **Installation Status Updater** tracking, which only checks the active play action — the root cause of #30.

Closes #30.

## Context

Before this change, `EnsureSteamLaunchAction` always forced the Steam URL action to `IsPlayAction=true` and demoted every other action. That broke Playnite's Installation Status Updater (it only inspects the active play action) and made the `{InstallDir}`-based file action unreachable. The user had no way to bulk-revert.

## Changes

- **`GameActionUtilities.EnsureSteamLaunchAction`** — new `steamActionIsDefault` parameter. When `false`, it demotes Steam and promotes a File action (preferring "Play (Direct)", falling back to any File action, then Steam only if no File action exists). Enforces a single default via a uniform loop. Previously the `false` path could only *promote* Steam, so the true→false toggle was a no-op for games imported under the old default-on setting.
- **`PluginSettings`** — new `SteamActionIsDefault` property (default `true`, persisted). On change in `EndEdit`, triggers a bulk reapply; failures are now logged instead of swallowed.
- **`PluginSettingsView`** — new checkbox, enabled only when "Launch via Steam" is on.
- **`ShortcutsLibrary.ReapplyPlayActionsForAllGames`** — selects games by the presence of a "Play (Steam)" URL action rather than `PluginId`, so games exported from other libraries (GOG/Epic/etc.) are re-defaulted too.
- All call sites (`ShortcutsLibrary`, `WriteBackHandler`, `ImportExportService`) pass the setting through.

## Tests

- All 206 existing tests pass.
- Added 3 tests covering the previously-broken transition:
  - `SteamActionNotDefault_DemotesSteamAndPromotesFile` — the exact issue #30 scenario.
  - `SteamActionNotDefault_ResolvesDoubleDefaultToFile`.
  - `SteamActionNotDefault_NoFileAction_KeepsSteamAsDefault`.