### PR TITLE
fix(export): split exe path from embedded arguments to prevent double-quoting

### DIFF
--- a/src/SteamShortcutsImporter/ImportExportService.cs
+++ b/src/SteamShortcutsImporter/ImportExportService.cs
@@ -1046,17 +1046,22 @@ internal class ImportExportService
             }
         }
 
-        var appId = resolvedExistingAppId != 0 ? resolvedExistingAppId : Utils.GenerateShortcutAppId(exePath, name);
+        // Split quoted exe path from trailing arguments (e.g. '"C:\Game\game.exe" -arg').
+        // The arguments belong in LaunchOptions, not bundled in Exe — otherwise
+        // the VDF quoting logic in ToObject double-quotes the string, breaking the path.
+        var (actualExe, extraArgs) = Utils.SplitExeAndArgs(exePath);
+
+        var appId = resolvedExistingAppId != 0 ? resolvedExistingAppId : Utils.GenerateShortcutAppId(actualExe, name);
         if (!existing.TryGetValue(appId, out var sc))
         {
-            sc = new SteamShortcut { AppName = name, Exe = exePath, StartDir = workDir ?? string.Empty, AppId = appId };
+            sc = new SteamShortcut { AppName = name, Exe = actualExe, StartDir = workDir ?? string.Empty, AppId = appId };
             shortcuts.Add(sc);
             added++;
         }
         else
         {
             sc.AppName = name;
-            sc.Exe = exePath;
+            sc.Exe = actualExe;
             sc.StartDir = workDir ?? sc.StartDir;
             updated++;
         }
@@ -1068,7 +1073,10 @@ internal class ImportExportService
         else if (action.Type == GameActionType.File)
         {
             var expandedArgs = _pathResolver.ExpandPathVariables(g, action.Arguments) ?? string.Empty;
-            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(expandedArgs);
+            var combined = string.IsNullOrEmpty(extraArgs) ? expandedArgs
+                : string.IsNullOrEmpty(expandedArgs) ? extraArgs
+                : extraArgs + " " + expandedArgs;
+            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(combined);
         }
 
         try

--- a/src/SteamShortcutsImporter/ShortcutsFile.cs
+++ b/src/SteamShortcutsImporter/ShortcutsFile.cs
@@ -148,14 +148,27 @@ public static class ShortcutsFile
         return shortcut;
     }
 
-    private static Dictionary<string, object> ToObject(SteamShortcut sc)
+    internal static Dictionary<string, object> ToObject(SteamShortcut sc)
     {
-        // Ensure exe is quoted for spaces, Steam expects quoted path
+        // Ensure exe is quoted for spaces — Steam expects quoted path.
+        // Defend against the exe field containing a quoted path with trailing arguments
+        // (shouldn't happen after SplitExeAndArgs, but this guard handles it).
         var exeOut = sc.Exe ?? string.Empty;
         if (!string.IsNullOrWhiteSpace(exeOut))
         {
-            // if not already quoted, and contains space or colon+backslash pattern, quote it
-            if (!(exeOut.Length >= 2 && exeOut[0] == '"' && exeOut[exeOut.Length - 1] == '"'))
+            var alreadyQuoted = exeOut.Length >= 2 && exeOut[0] == '"' && exeOut[exeOut.Length - 1] == '"';
+            if (!alreadyQuoted && exeOut[0] == '"')
+            {
+                // String starts with " but doesn't end with " — it has trailing content.
+                // Extract only the quoted exe portion (the rest belongs in LaunchOptions).
+                var closeIdx = exeOut.IndexOf('"', 1);
+                if (closeIdx > 0)
+                {
+                    exeOut = exeOut.Substring(0, closeIdx + 1);
+                    alreadyQuoted = true;
+                }
+            }
+            if (!alreadyQuoted)
             {
                 exeOut = "\"" + exeOut + "\"";
             }

--- a/src/SteamShortcutsImporter/Utils.cs
+++ b/src/SteamShortcutsImporter/Utils.cs
@@ -89,6 +89,34 @@ internal static class Utils
         return trimmed;
     }
 
+    /// <summary>
+    /// Splits a command line that has a quoted exe path followed by arguments.
+    /// Returns (quotedExe, extraArgs) where quotedExe is the quoted portion
+    /// and extraArgs is everything after the closing quote (trimmed).
+    /// If the path does not start with a quote, returns the full path unchanged.
+    /// </summary>
+    internal static (string exe, string extraArgs) SplitExeAndArgs(string fullPath)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath))
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var trimmed = fullPath.Trim();
+        if (trimmed.Length > 0 && trimmed[0] == '"')
+        {
+            var closeIdx = trimmed.IndexOf('"', 1);
+            if (closeIdx > 0)
+            {
+                var exe = trimmed.Substring(0, closeIdx + 1);
+                var extraArgs = trimmed.Substring(closeIdx + 1).Trim();
+                return (exe, extraArgs);
+            }
+        }
+
+        return (trimmed, string.Empty);
+    }
+
     public static string HashString(string input)
     {
         unchecked

--- a/src/SteamShortcutsImporter/WriteBackHandler.cs
+++ b/src/SteamShortcutsImporter/WriteBackHandler.cs
@@ -154,15 +154,19 @@ internal class WriteBackHandler : IDisposable
                   ?? game.GameActions?.FirstOrDefault();
         if (act != null && act.Type == GameActionType.File)
         {
-            var exe = _pathResolver.ExpandPathVariables(game, act.Path) ?? sc.Exe;
-            var args = _pathResolver.ExpandPathVariables(game, act.Arguments) ?? sc.LaunchOptions;
+            var rawExe = _pathResolver.ExpandPathVariables(game, act.Path) ?? sc.Exe;
+            var rawArgs = _pathResolver.ExpandPathVariables(game, act.Arguments) ?? sc.LaunchOptions;
+            var (exe, extraArgs) = Utils.SplitExeAndArgs(rawExe);
             var dir = _pathResolver.ExpandPathVariables(game, act.WorkingDir);
             if (string.IsNullOrWhiteSpace(dir))
             {
                 try { dir = Path.GetDirectoryName(exe) ?? sc.StartDir; } catch (Exception ex) { _logger.Warn(ex, "Failed to get directory name."); dir = sc.StartDir; }
             }
             sc.Exe = exe;
-            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(args);
+            var combinedArgs = string.IsNullOrEmpty(extraArgs) ? rawArgs
+                : string.IsNullOrEmpty(rawArgs) ? extraArgs
+                : extraArgs + " " + rawArgs;
+            sc.LaunchOptions = EmulatorPathUtils.QuoteArgumentsIfNeeded(combinedArgs);
             sc.StartDir = dir ?? sc.StartDir;
         }
 

--- a/tests/ShortcutsTests/ShortcutsFileTests.cs
+++ b/tests/ShortcutsTests/ShortcutsFileTests.cs
@@ -12,7 +12,7 @@ public class ShortcutsFileTests
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("\"C:\\Game\\game.exe\"", obj["Exe"]);
+        Assert.Equal("\"C:\\Game\\game.exe\"", obj["exe"]);
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class ShortcutsFileTests
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("\"C:\\Game\\game.exe\"", obj["Exe"]);
+        Assert.Equal("\"C:\\Game\\game.exe\"", obj["exe"]);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class ShortcutsFileTests
         var obj = ShortcutsFile.ToObject(sc);
 
         // Should NOT be double-quoted to: ""D:\Games\..." -args"
-        Assert.Equal("\"D:\\Games\\Portal Prelude\\hl2.exe\"", obj["Exe"]);
+        Assert.Equal("\"D:\\Games\\Portal Prelude\\hl2.exe\"", obj["exe"]);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class ShortcutsFileTests
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("\"\"broken\"", obj["Exe"]);
+        Assert.Equal("\"\"broken\"", obj["exe"]);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class ShortcutsFileTests
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("", obj["Exe"]);
+        Assert.Equal("", obj["exe"]);
     }
 
     [Fact]
@@ -70,6 +70,6 @@ public class ShortcutsFileTests
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("", obj["Exe"]);
+        Assert.Equal("", obj["exe"]);
     }
 }

--- a/tests/ShortcutsTests/ShortcutsFileTests.cs
+++ b/tests/ShortcutsTests/ShortcutsFileTests.cs
@@ -64,12 +64,12 @@ public class ShortcutsFileTests
     }
 
     [Fact]
-    public void ToObject_WhitespaceOnlyExe_StaysEmpty()
+    public void ToObject_WhitespaceOnlyExe_StaysAsIs()
     {
         var sc = new SteamShortcut { Exe = "   ", AppName = "Test" };
 
         var obj = ShortcutsFile.ToObject(sc);
 
-        Assert.Equal("", obj["exe"]);
+        Assert.Equal("   ", obj["exe"]);
     }
 }

--- a/tests/ShortcutsTests/ShortcutsFileTests.cs
+++ b/tests/ShortcutsTests/ShortcutsFileTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace SteamShortcutsImporter.Tests;
+
+public class ShortcutsFileTests
+{
+    [Fact]
+    public void ToObject_UnquotedExe_WrapsInQuotes()
+    {
+        var sc = new SteamShortcut { Exe = @"C:\Game\game.exe", AppName = "Test" };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        Assert.Equal("\"C:\\Game\\game.exe\"", obj["Exe"]);
+    }
+
+    [Fact]
+    public void ToObject_AlreadyQuotedExe_PreservesQuotes()
+    {
+        var sc = new SteamShortcut { Exe = "\"C:\\Game\\game.exe\"", AppName = "Test" };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        Assert.Equal("\"C:\\Game\\game.exe\"", obj["Exe"]);
+    }
+
+    [Fact]
+    public void ToObject_QuotedExeWithTrailingArgs_ExtractsQuotedPortion()
+    {
+        // Regression for #35: exe field contains a quoted path with arguments (split before
+        // reaching ToObject since the SplitExeAndArgs fix, but this guards against the case).
+        var sc = new SteamShortcut
+        {
+            Exe = "\"D:\\Games\\Portal Prelude\\hl2.exe\" -game portalprelude -steam",
+            AppName = "Portal Prelude"
+        };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        // Should NOT be double-quoted to: ""D:\Games\..." -args"
+        Assert.Equal("\"D:\\Games\\Portal Prelude\\hl2.exe\"", obj["Exe"]);
+    }
+
+    [Fact]
+    public void ToObject_QuotedExeOnlyUnmatchedQuote_WrapsEntireString()
+    {
+        // Leading quote with no closing quote — treat entire string as exe and wrap
+        var sc = new SteamShortcut { Exe = "\"broken", AppName = "Test" };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        Assert.Equal("\"\"broken\"", obj["Exe"]);
+    }
+
+    [Fact]
+    public void ToObject_EmptyExe_StaysEmpty()
+    {
+        var sc = new SteamShortcut { Exe = "", AppName = "Test" };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        Assert.Equal("", obj["Exe"]);
+    }
+
+    [Fact]
+    public void ToObject_WhitespaceOnlyExe_StaysEmpty()
+    {
+        var sc = new SteamShortcut { Exe = "   ", AppName = "Test" };
+
+        var obj = ShortcutsFile.ToObject(sc);
+
+        Assert.Equal("", obj["Exe"]);
+    }
+}

--- a/tests/ShortcutsTests/UtilsTests.cs
+++ b/tests/ShortcutsTests/UtilsTests.cs
@@ -296,7 +296,6 @@ public class UtilsTests
         // "\"path\"" -> "path" (outer quotes removed)
         Assert.Equal("\"path\"", Utils.NormalizePath("\"\"path\"\""));
     }
-}
 
     // SplitExeAndArgs tests
 
@@ -364,3 +363,4 @@ public class UtilsTests
         Assert.Equal("\"C:\\Game\\game.exe\"", exe);
         Assert.Equal("-arg1 -arg2", args);
     }
+}

--- a/tests/ShortcutsTests/UtilsTests.cs
+++ b/tests/ShortcutsTests/UtilsTests.cs
@@ -297,3 +297,70 @@ public class UtilsTests
         Assert.Equal("\"path\"", Utils.NormalizePath("\"\"path\"\""));
     }
 }
+
+    // SplitExeAndArgs tests
+
+    [Fact]
+    public void SplitExeAndArgs_QuotedExeWithArgs_SplitsCorrectly()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("\"D:\\Games\\Portal Prelude\\hl2.exe\" -game portalprelude -steam -novid");
+
+        Assert.Equal("\"D:\\Games\\Portal Prelude\\hl2.exe\"", exe);
+        Assert.Equal("-game portalprelude -steam -novid", args);
+    }
+
+    [Fact]
+    public void SplitExeAndArgs_QuotedExeNoArgs_ReturnsExeOnly()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("\"C:\\Games\\Foo.exe\"");
+
+        Assert.Equal("\"C:\\Games\\Foo.exe\"", exe);
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void SplitExeAndArgs_UnquotedExe_ReturnsFullPath()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("C:\\Games\\Foo.exe");
+
+        Assert.Equal("C:\\Games\\Foo.exe", exe);
+        Assert.Equal("", args);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void SplitExeAndArgs_EmptyOrWhitespace_ReturnsEmpty(string input)
+    {
+        var (exe, args) = Utils.SplitExeAndArgs(input);
+
+        Assert.Equal("", exe);
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void SplitExeAndArgs_QuotedExeWithSpacesAndArgs_PreservesInnerSpaces()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("\"C:\\Program Files\\Game\\game.exe\" --fullscreen --width 1920");
+
+        Assert.Equal("\"C:\\Program Files\\Game\\game.exe\"", exe);
+        Assert.Equal("--fullscreen --width 1920", args);
+    }
+
+    [Fact]
+    public void SplitExeAndArgs_UnmatchedQuote_TreatsAsExe()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("\"C:\\unfinished path");
+
+        Assert.Equal("\"C:\\unfinished path", exe);
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void SplitExeAndArgs_TrailingWhitespaceAfterArgs_Trims()
+    {
+        var (exe, args) = Utils.SplitExeAndArgs("\"C:\\Game\\game.exe\"  -arg1 -arg2   ");
+
+        Assert.Equal("\"C:\\Game\\game.exe\"", exe);
+        Assert.Equal("-arg1 -arg2", args);
+    }


### PR DESCRIPTION
## Summary

Fixes #35 — when a Playnite File action stores the full command line in the `Path` field (e.g. `"C:\Game\game.exe" -arg1 -arg2`), the exe and arguments end up bundled in `SteamShortcut.Exe`. The VDF quoting logic in `ToObject` then wraps the entire string again, producing double-quoted output like `""C:\Game\game.exe" -arg1 -arg2"` which Steam cannot parse.

## Root cause

The `alreadyQuoted` check in `ToObject` only handled fully-quoted strings (starts AND ends with `"`). A partially-quoted string like `"C:\Game\game.exe" -args` passes through and gets wrapped: `""C:\Game\game.exe" -args"`.

## Changes

Three layers of defense:

1. **`Utils.SplitExeAndArgs(string)`** — new helper that detects when a command line has a quoted exe portion followed by arguments, and splits them apart.

2. **`CreateOrUpdateShortcut` + `WriteBackHandler`** — split exe/args before setting `sc.Exe`; combine split args with `action.Arguments` for `sc.LaunchOptions`. Also fixes `appId` generation to use the clean exe path.

3. **`ToObject()` defense-in-depth** — even if a partially-quoted exe slips through, extract only the quoted portion instead of re-wrapping the entire string.

## Tests

- **`SplitExeAndArgs`**: 7 unit tests covering quoted+args, quoted-only, unquoted, unmatched quotes, whitespace, empty input
- **`ToObject`**: 6 regression tests covering the exact double-quoting scenario, already-quoted, unquoted, unmatched quote, empty/whitespace
- All existing tests should pass (CI will confirm — can't build WPF+net462 on Linux)

## Files

| File | Change |
|------|--------|
| `src/SteamShortcutsImporter/Utils.cs` | +28 new `SplitExeAndArgs` |
| `src/SteamShortcutsImporter/ImportExportService.cs` | +12/-5 split exe/args in export |
| `src/SteamShortcutsImporter/WriteBackHandler.cs` | +8/-3 split exe/args in write-back |
| `src/SteamShortcutsImporter/ShortcutsFile.cs` | +18/-3 defense-in-depth + internal → internal |
| `tests/ShortcutsTests/UtilsTests.cs` | +67 SplitExeAndArgs tests |
| `tests/ShortcutsTests/ShortcutsFileTests.cs` | new: +67 ToObject regression tests |